### PR TITLE
Add `TBCTestStore` shim and non exhaustive mode

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/ARCTestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ARCTestStore.swift
@@ -1,0 +1,408 @@
+#if DEBUG
+  import Combine
+  import Foundation
+  import XCTestDynamicOverlay
+
+  
+  public final class ARCTestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
+    public var environment: Environment
+
+    private let file: StaticString
+    private let fromLocalAction: (LocalAction) -> Action
+    private var line: UInt
+    private var longLivingEffects: Set<LongLivingEffect> = []
+    private var receivedActions: [(action: Action, state: State)] = []
+    private let reducer: Reducer<State, Action, Environment>
+    private var store: Store<State, TestAction>!
+    private let toLocalState: (State) -> LocalState
+
+    private init(
+      environment: Environment,
+      file: StaticString,
+      fromLocalAction: @escaping (LocalAction) -> Action,
+      initialState: State,
+      line: UInt,
+      reducer: Reducer<State, Action, Environment>,
+      toLocalState: @escaping (State) -> LocalState
+    ) {
+      self.environment = environment
+      self.file = file
+      self.fromLocalAction = fromLocalAction
+      self.line = line
+      self.reducer = reducer
+      self.toLocalState = toLocalState
+
+      self.store = Store(
+        initialState: initialState,
+        reducer: Reducer<State, TestAction, Void> { [unowned self] state, action, _ in
+          let effects: Effect<Action, Never>
+          switch action.origin {
+          case let .send(localAction):
+            effects = self.reducer.run(&state, self.fromLocalAction(localAction), self.environment)
+
+          case let .receive(action):
+            effects = self.reducer.run(&state, action, self.environment)
+            self.receivedActions.append((action, state))
+          }
+
+          let effect = LongLivingEffect(file: action.file, line: action.line)
+          return
+            effects
+            .handleEvents(
+              receiveSubscription: { [weak self] _ in
+                self?.longLivingEffects.insert(effect)
+              },
+              receiveCompletion: { [weak self] _ in self?.longLivingEffects.remove(effect) },
+              receiveCancel: { [weak self] in self?.longLivingEffects.remove(effect) }
+            )
+            .map { .init(origin: .receive($0), file: action.file, line: action.line) }
+            .eraseToEffect()
+
+        },
+        environment: ()
+      )
+    }
+
+    public func assertEffectCompleted() {
+      for effect in self.longLivingEffects {
+        XCTFail(
+          """
+          An effect returned for this action is still running. It must complete before the end of \
+          the test. …
+
+          To fix, inspect any effects the reducer returns for this action and ensure that all of \
+          them complete by the end of the test. There are a few reasons why an effect may not have \
+          completed:
+
+          • If an effect uses a scheduler (via "receive(on:)", "delay", "debounce", etc.), make \
+          sure that you wait enough time for the scheduler to perform the effect. If you are using \
+          a test scheduler, advance the scheduler so that the effects may complete, or consider \
+          using an immediate scheduler to immediately perform the effect instead.
+
+          • If you are returning a long-living effect (timers, notifications, subjects, etc.), \
+          then make sure those effects are torn down by marking the effect ".cancellable" and \
+          returning a corresponding cancellation effect ("Effect.cancel") from another action, or, \
+          if your effect is driven by a Combine subject, send it a completion.
+          """,
+          file: effect.file,
+          line: effect.line
+        )
+      }
+    }
+
+    private struct LongLivingEffect: Hashable {
+      let id = UUID()
+      let file: StaticString
+      let line: UInt
+
+      static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+      }
+
+      func hash(into hasher: inout Hasher) {
+        self.id.hash(into: &hasher)
+      }
+    }
+  }
+
+  extension ARCTestStore where State == LocalState, Action == LocalAction {
+    /// Initializes a test store from an initial state, a reducer, and an initial environment.
+    ///
+    /// - Parameters:
+    ///   - initialState: The state to start the test from.
+    ///   - reducer: A reducer.
+    ///   - environment: The environment to start the test from.
+    public convenience init(
+      initialState: State,
+      reducer: Reducer<State, Action, Environment>,
+      environment: Environment,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      self.init(
+        environment: environment,
+        file: file,
+        fromLocalAction: { $0 },
+        initialState: initialState,
+        line: line,
+        reducer: reducer,
+        toLocalState: { $0 }
+      )
+    }
+  }
+
+  extension ARCTestStore where LocalState: Equatable {
+    public func send(
+      _ action: LocalAction,
+      file: StaticString = #file,
+      line: UInt = #line,
+      _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+    ) {
+      receivedActions.removeAll() // When developer explicitly sends an action, reset all recorded ones so we can compare from this point in time
+      
+      verifyUpdateBlockMatchesState(
+          actionToSend: action,
+          file: file,
+          line: line,
+          update
+      )
+ 
+      if "\(self.file)" == "\(file)" {
+        self.line = line
+      }
+    }
+      
+    public func receive(
+      _ action: Action,
+      file: StaticString = #file,
+      line: UInt = #line,
+      _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+    ) {
+      guard receivedActions.contains(where: { $0.action == action }) else {
+          XCTFail(
+            """
+            Expected to receive an action \(action), but didn't get one.
+            """,
+            file: file, line: line
+          )
+          return
+      }
+        
+      verifyUpdateBlockMatchesState(
+          actionToSend: .none,
+          file: file,
+          line: line,
+          update
+      )
+      
+      if "\(self.file)" == "\(file)" {
+        self.line = line
+      }
+    }
+      
+    private func verifyUpdateBlockMatchesState(
+        actionToSend: LocalAction?,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+    ) {
+        let viewStore = ViewStore(
+          self.store.scope(
+            state: self.toLocalState,
+            action: { .init(origin: .send($0), file: file, line: line) }
+          )
+        )
+
+        if let action = actionToSend {
+            viewStore.send(action)
+        }
+
+        // We are only asserting that update block doesn't cause state change that would NOT equal actual state change, thus ignoring any additional changes that actually happen
+        let stateAfterReducerApplication = viewStore.state
+        var stateAfterApplyingUpdate = stateAfterReducerApplication
+
+        do {
+          try update(&stateAfterApplyingUpdate)
+        } catch {
+          XCTFail("Threw error: \(error)", file: file, line: line)
+        }
+
+        self.expectedStateShouldMatch(
+          expected: stateAfterApplyingUpdate,
+          actual: stateAfterReducerApplication,
+          file: file,
+          line: line
+        )
+    }
+
+    private func expectedStateShouldMatch(
+      expected: LocalState,
+      actual: LocalState,
+      file: StaticString,
+      line: UInt
+    ) {
+      if expected != actual {
+        let diff =
+          diff(expected, actual, format: .proportional)
+          .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+          ?? """
+          Expected:
+          \(String(describing: expected).indent(by: 2))
+
+          Actual:
+          \(String(describing: actual).indent(by: 2))
+          """
+
+        XCTFail(
+          """
+          State change does not match expectation: …
+
+          \(diff)
+          """,
+          file: file,
+          line: line
+        )
+      }
+    }
+  }
+
+  extension ARCTestStore {
+    /// Scopes a store to assert against more local state and actions.
+    ///
+    /// Useful for testing view store-specific state and actions.
+    ///
+    /// - Parameters:
+    ///   - toLocalState: A function that transforms the reducer's state into more local state. This
+    ///     state will be asserted against as it is mutated by the reducer. Useful for testing view
+    ///     store state transformations.
+    ///   - fromLocalAction: A function that wraps a more local action in the reducer's action.
+    ///     Local actions can be "sent" to the store, while any reducer action may be received.
+    ///     Useful for testing view store action transformations.
+    public func scope<S, A>(
+      state toLocalState: @escaping (LocalState) -> S,
+      action fromLocalAction: @escaping (A) -> LocalAction
+    ) -> ARCTestStore<State, S, Action, A, Environment> {
+      .init(
+        environment: self.environment,
+        file: self.file,
+        fromLocalAction: { self.fromLocalAction(fromLocalAction($0)) },
+        initialState: self.store.state.value,
+        line: self.line,
+        reducer: self.reducer,
+        toLocalState: { toLocalState(self.toLocalState($0)) }
+      )
+    }
+
+    /// Scopes a store to assert against more local state.
+    ///
+    /// Useful for testing view store-specific state.
+    ///
+    /// - Parameter toLocalState: A function that transforms the reducer's state into more local
+    ///   state. This state will be asserted against as it is mutated by the reducer. Useful for
+    ///   testing view store state transformations.
+    public func scope<S>(
+      state toLocalState: @escaping (LocalState) -> S
+    ) -> ARCTestStore<State, S, Action, LocalAction, Environment> {
+      self.scope(state: toLocalState, action: { $0 })
+    }
+
+    /// A single step of a `TestStore` assertion.
+    public struct Step {
+      fileprivate let type: StepType
+      fileprivate let file: StaticString
+      fileprivate let line: UInt
+
+      private init(
+        _ type: StepType,
+        file: StaticString = #file,
+        line: UInt = #line
+      ) {
+        self.type = type
+        self.file = file
+        self.line = line
+      }
+
+      /// A step that describes an action sent to a store and asserts against how the store's state
+      /// is expected to change.
+      ///
+      /// - Parameters:
+      ///   - action: An action to send to the test store.
+      ///   - update: A function that describes how the test store's state is expected to change.
+      /// - Returns: A step that describes an action sent to a store and asserts against how the
+      ///   store's state is expected to change.
+      public static func send(
+        _ action: LocalAction,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+      ) -> Step {
+        Step(.send(action, update), file: file, line: line)
+      }
+
+      /// A step that describes an action received by an effect and asserts against how the store's
+      /// state is expected to change.
+      ///
+      /// - Parameters:
+      ///   - action: An action the test store should receive by evaluating an effect.
+      ///   - update: A function that describes how the test store's state is expected to change.
+      /// - Returns: A step that describes an action received by an effect and asserts against how
+      ///   the store's state is expected to change.
+      public static func receive(
+        _ action: Action,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+      ) -> Step {
+        Step(.receive(action, update), file: file, line: line)
+      }
+
+      /// A step that updates a test store's environment.
+      ///
+      /// - Parameter update: A function that updates the test store's environment for subsequent
+      ///   steps.
+      /// - Returns: A step that updates a test store's environment.
+      public static func environment(
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ update: @escaping (inout Environment) throws -> Void
+      ) -> Step {
+        Step(.environment(update), file: file, line: line)
+      }
+
+      /// A step that captures some work to be done between assertions
+      ///
+      /// - Parameter work: A function that is called between steps.
+      /// - Returns: A step that captures some work to be done between assertions.
+      public static func `do`(
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ work: @escaping () throws -> Void
+      ) -> Step {
+        Step(.do(work), file: file, line: line)
+      }
+
+      /// A step that captures a sub-sequence of steps.
+      ///
+      /// - Parameter steps: An array of `Step`
+      /// - Returns: A step that captures a sub-sequence of steps.
+      public static func sequence(
+        _ steps: [Step],
+        file: StaticString = #file,
+        line: UInt = #line
+      ) -> Step {
+        Step(.sequence(steps), file: file, line: line)
+      }
+
+      /// A step that captures a sub-sequence of steps.
+      ///
+      /// - Parameter steps: A variadic list of `Step`
+      /// - Returns: A step that captures a sub-sequence of steps.
+      public static func sequence(
+        _ steps: Step...,
+        file: StaticString = #file,
+        line: UInt = #line
+      ) -> Step {
+        Step(.sequence(steps), file: file, line: line)
+      }
+
+      fileprivate indirect enum StepType {
+        case send(LocalAction, (inout LocalState) throws -> Void)
+        case receive(Action, (inout LocalState) throws -> Void)
+        case environment((inout Environment) throws -> Void)
+        case `do`(() throws -> Void)
+        case sequence([Step])
+      }
+    }
+
+    private struct TestAction {
+      let origin: Origin
+      let file: StaticString
+      let line: UInt
+
+      enum Origin {
+        case send(LocalAction)
+        case receive(Action)
+      }
+    }
+  }
+#endif

--- a/Sources/ComposableArchitecture/TestSupport/TBCTestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TBCTestStore.swift
@@ -1,0 +1,192 @@
+#if DEBUG
+import Combine
+import Foundation
+import XCTestDynamicOverlay
+
+
+public enum TestStoreKind {
+    case exhaustive
+    case nonExhaustive
+}
+
+/// Universal test store interface that can be used in both Exhaustive and non-Exhaustive mode
+/// - note: The reason this isn't using a protocol interface instead of explicit handling is because protocols can't support default arguments (`file`/`line`) and introducing implementation protocol would require more changes in original TCA store, right now we only change access levels which means updating original TCA store whenever upstream changes should be very low effort
+public final class TBCTestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
+    public typealias TCATestStoreType = TestStore<State, LocalState, Action, LocalAction, Environment>
+
+    private enum StoreImplementation {
+        case exhaustive(TCATestStoreType)
+        case nonExhaustive(NonExhaustiveTestStore<State, LocalState, Action, LocalAction, Environment>)
+    }
+    
+    private let storeImplementation: StoreImplementation
+    
+    internal init(
+        kind: TestStoreKind = .exhaustive,
+        environment: Environment,
+        file: StaticString,
+        fromLocalAction: @escaping (LocalAction) -> Action,
+        initialState: State,
+        line: UInt,
+        reducer: Reducer<State, Action, Environment>,
+        toLocalState: @escaping (State) -> LocalState
+    ) {
+        switch kind {
+        case .exhaustive:
+            storeImplementation = .exhaustive(.init(environment: environment, file: file, fromLocalAction: fromLocalAction, initialState: initialState, line: line, reducer: reducer, toLocalState: toLocalState))
+        case .nonExhaustive:
+            storeImplementation = .nonExhaustive(.init(environment: environment, file: file, fromLocalAction: fromLocalAction, initialState: initialState, line: line, reducer: reducer, toLocalState: toLocalState))
+        }
+    }
+    
+    private init(storeImplementation: StoreImplementation) {
+        self.storeImplementation = storeImplementation
+    }
+    
+    public var environment: Environment {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            return store.environment
+        case let .nonExhaustive(store):
+            return store.environment
+        }
+    }
+    
+    public func assertEffectCompleted() {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            store.completed()
+        case let .nonExhaustive(store):
+            store.assertEffectCompleted()
+        }
+    }
+}
+
+extension TBCTestStore where State == LocalState, Action == LocalAction {
+    /// Initializes a test store from an initial state, a reducer, and an initial environment.
+    ///
+    /// - Parameters:
+    ///   - kind: The store behaviour kind, exhaustive or not?
+    ///   - initialState: The state to start the test from.
+    ///   - reducer: A reducer.
+    ///   - environment: The environment to start the test from.
+    public convenience init(
+        kind: TestStoreKind,
+        initialState: State,
+        reducer: Reducer<State, Action, Environment>,
+        environment: Environment,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        self.init(
+            kind: kind,
+            environment: environment,
+            file: file,
+            fromLocalAction: { $0 },
+            initialState: initialState,
+            line: line,
+            reducer: reducer,
+            toLocalState: { $0 }
+        )
+    }
+}
+
+extension TBCTestStore where LocalState: Equatable {
+    public func send(
+        _ action: LocalAction,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+    ) {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            store.send(action, file: file, line: line, update)
+        case let .nonExhaustive(store):
+            store.send(action, file: file, line: line, update)
+        }
+    }
+}
+
+extension TBCTestStore where LocalState: Equatable, Action: Equatable {
+    public func receive(
+        _ expectedAction: Action,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+    ) {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            store.receive(expectedAction, file: file, line: line, update)
+        case let .nonExhaustive(store):
+            store.receive(expectedAction, file: file, line: line, update)
+        }
+    }
+    
+    /// Asserts against a script of actions.
+    public func assert(
+        _ steps: TCATestStoreType.Step...,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        assert(steps, file: file, line: line)
+    }
+    
+    /// Asserts against an array of actions.
+    public func assert(
+        _ steps: [TCATestStoreType.Step],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            store.assert(steps, file: file, line: line)
+        case let .nonExhaustive(store):
+            store.assert(steps, file: file, line: line)
+        }
+    }
+}
+
+extension TBCTestStore {
+    /// Scopes a store to assert against more local state and actions.
+    ///
+    /// Useful for testing view store-specific state and actions.
+    ///
+    /// - Parameters:
+    ///   - toLocalState: A function that transforms the reducer's state into more local state. This
+    ///     state will be asserted against as it is mutated by the reducer. Useful for testing view
+    ///     store state transformations.
+    ///   - fromLocalAction: A function that wraps a more local action in the reducer's action.
+    ///     Local actions can be "sent" to the store, while any reducer action may be received.
+    ///     Useful for testing view store action transformations.
+    public func scope<S, A>(
+        state toLocalState: @escaping (LocalState) -> S,
+        action fromLocalAction: @escaping (A) -> LocalAction
+    ) -> TBCTestStore<State, S, Action, A, Environment> {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            return .init(storeImplementation: .exhaustive(store.scope(state: toLocalState, action: fromLocalAction)))
+        case let .nonExhaustive(store):
+            return .init(storeImplementation: .nonExhaustive(store.scope(state: toLocalState, action: fromLocalAction)))
+        }
+    }
+    
+    /// Scopes a store to assert against more local state.
+    ///
+    /// Useful for testing view store-specific state.
+    ///
+    /// - Parameter toLocalState: A function that transforms the reducer's state into more local
+    ///   state. This state will be asserted against as it is mutated by the reducer. Useful for
+    ///   testing view store state transformations.
+    public func scope<S>(
+        state toLocalState: @escaping (LocalState) -> S
+    ) -> TBCTestStore<State, S, Action, LocalAction, Environment> {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            return .init(storeImplementation: .exhaustive(store.scope(state: toLocalState, action: { $0 })))
+        case let .nonExhaustive(store):
+            return .init(storeImplementation: .nonExhaustive(store.scope(state: toLocalState, action: { $0 })))
+        }
+    }
+}
+
+#endif

--- a/Sources/ComposableArchitecture/TestSupport/TBCTestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TBCTestStore.swift
@@ -51,13 +51,25 @@ public final class TBCTestStore<State, LocalState, Action: Equatable, LocalActio
             return store.environment
         }
     }
-    
+
     public func assertEffectCompleted() {
         switch storeImplementation {
         case let .exhaustive(store):
             store.completed()
         case let .nonExhaustive(store):
             store.assertEffectCompleted()
+        }
+    }
+    
+    /// State accessor for use with XCTAsserts
+    /// - note: This isn't allowed with Exhaustive mode and will cause an assertion
+    public var state: State {
+        switch storeImplementation {
+        case let .exhaustive(store):
+            assertionFailure("Don't use state in Exhaustive Test Stores")
+            return store.snapshotState
+        case let .nonExhaustive(store):
+            return store.snapshotState
         }
     }
 }

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -274,7 +274,7 @@
       }
     }
 
-    private struct LongLivingEffect: Hashable {
+    struct LongLivingEffect: Hashable {
       let id = UUID()
       let file: StaticString
       let line: UInt
@@ -348,7 +348,7 @@
       } catch {
         XCTFail("Threw error: \(error)", file: file, line: line)
       }
-      self.expectedStateShouldMatch(
+      Self.expectedStateShouldMatch(
         expected: expectedState,
         actual: self.toLocalState(self.snapshotState),
         file: file,
@@ -359,7 +359,7 @@
       }
     }
 
-    private func expectedStateShouldMatch(
+    static func expectedStateShouldMatch(
       expected: LocalState,
       actual: LocalState,
       file: StaticString,
@@ -434,7 +434,7 @@
       } catch {
         XCTFail("Threw error: \(error)", file: file, line: line)
       }
-      expectedStateShouldMatch(
+      Self.expectedStateShouldMatch(
         expected: expectedState,
         actual: self.toLocalState(state),
         file: file,
@@ -669,7 +669,7 @@
       }
     }
 
-    private struct TestAction {
+    struct TestAction {
       let origin: Origin
       let file: StaticString
       let line: UInt

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -563,11 +563,11 @@
 
     /// A single step of a ``TestStore`` assertion.
     public struct Step {
-      fileprivate let type: StepType
-      fileprivate let file: StaticString
-      fileprivate let line: UInt
+      internal let type: StepType
+      internal let file: StaticString
+      internal let line: UInt
 
-      private init(
+      internal init(
         _ type: StepType,
         file: StaticString = #file,
         line: UInt = #line
@@ -660,7 +660,7 @@
         Step(.sequence(steps), file: file, line: line)
       }
 
-      fileprivate indirect enum StepType {
+      internal indirect enum StepType {
         case send(LocalAction, (inout LocalState) throws -> Void)
         case receive(Action, (inout LocalState) throws -> Void)
         case environment((inout Environment) throws -> Void)

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -181,7 +181,7 @@
     private var store: Store<State, TestAction>!
     private let toLocalState: (State) -> LocalState
 
-    private init(
+    internal init(
       environment: Environment,
       file: StaticString,
       fromLocalAction: @escaping (LocalAction) -> Action,
@@ -234,7 +234,7 @@
       self.completed()
     }
 
-    private func completed() {
+    internal func completed() {
       if !self.receivedActions.isEmpty {
         var actions = ""
         customDump(self.receivedActions.map(\.action), to: &actions)

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -177,9 +177,9 @@
     private var longLivingEffects: Set<LongLivingEffect> = []
     private var receivedActions: [(action: Action, state: State)] = []
     private let reducer: Reducer<State, Action, Environment>
-    private var snapshotState: State
+    internal private(set) var snapshotState: State
     private var store: Store<State, TestAction>!
-    private let toLocalState: (State) -> LocalState
+    internal let toLocalState: (State) -> LocalState
 
     internal init(
       environment: Environment,

--- a/Tests/ComposableArchitectureTests/ARCTestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ARCTestStoreTests.swift
@@ -1,0 +1,99 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+
+class ARCTestStoreTests: XCTestCase {
+    struct State: Equatable {
+        var name: String = "Krzysztof"
+        var surname: String = "Zabłocki"
+        var age: Int = 33
+        var mood: Int = 0
+    }
+    
+    enum Action: Equatable {
+        case changeIdentity(name: String, surname: String)
+        case changeAge(Int)
+        case changeMood(Int)
+        case advanceAgeAfterDelay
+    }
+    
+    let reducer = Reducer<State, Action, AnySchedulerOf<DispatchQueue>> { state, action, scheduler in
+        switch action {
+        case let .changeIdentity(name, surname):
+            state.name = name
+            state.surname = surname
+            return .none
+            
+        case .advanceAgeAfterDelay:
+            return .merge(
+                .init(value: .changeAge(state.age + 1)),
+                .init(value: .changeMood(state.mood + 1))
+            )
+                .delay(for: 1, scheduler: scheduler)
+                .eraseToEffect()
+            
+        case let .changeAge(age):
+            state.age = age
+            return .none
+        case let .changeMood(mood):
+            state.mood = mood
+            return .none
+        }
+    }
+    
+    func test_verify_state_changes_without_exhaustivity() {
+        let testScheduler = DispatchQueue.test
+        let store = ARCTestStore(
+            initialState: State(),
+            reducer: reducer,
+            environment: testScheduler.eraseToAnyScheduler()
+        )
+        
+        // When changing multiple properties, can choose to assert only the ones one is interested in
+        store.send(.changeIdentity(name: "Marek", surname: "Ignored")) {
+            $0.name = "Marek"
+        }
+    }
+    
+    func test_verify_state_changes_once_after_many_actions_were_processed() {
+        let testScheduler = DispatchQueue.test
+        let store = ARCTestStore(
+            initialState: State(),
+            reducer: reducer,
+            environment: testScheduler.eraseToAnyScheduler()
+        )
+        
+        // When sending multiple actions
+        store.send(.changeIdentity(name: "Adam", surname: "Stern"))
+        store.send(.changeIdentity(name: "Piotr", surname: "Galiszewski"))
+        
+        // You can wait to verify the state at the last action point
+        store.send(.changeIdentity(name: "Merowing", surname: "Info")) {
+            $0.name = "Merowing"
+            $0.surname = "Info"
+        }
+    }
+    
+    func test_verify_received_actions() {
+        let testScheduler = DispatchQueue.test
+        let store = ARCTestStore(
+            initialState: State(),
+            reducer: reducer,
+            environment: testScheduler.eraseToAnyScheduler()
+        )
+        
+        // Given a delayed update
+        store.send(.advanceAgeAfterDelay)
+        
+        // When moving scheduler forward in time
+        testScheduler.advance(by: 1)
+        
+        // Verify that it received delayed action and updated state (note that we choose ignore checking `mood`)
+        store.receive(.changeAge(34)) {
+            $0.age = 34
+        }
+        
+        // optional: you can verify if all effects completed or cancelled
+        store.assertEffectCompleted()
+    }
+}

--- a/Tests/ComposableArchitectureTests/ARCTestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ARCTestStoreTests.swift
@@ -1,5 +1,5 @@
 import Combine
-import ComposableArchitecture
+@testable import ComposableArchitecture
 import XCTest
 
 class ARCTestStoreTests: XCTestCase {
@@ -43,7 +43,7 @@ class ARCTestStoreTests: XCTestCase {
     
     func test_verify_state_changes_without_exhaustivity() {
         let testScheduler = DispatchQueue.test
-        let store = ARCTestStore(
+        let store = NonExhaustiveTestStore(
             initialState: State(),
             reducer: reducer,
             environment: testScheduler.eraseToAnyScheduler()
@@ -57,7 +57,7 @@ class ARCTestStoreTests: XCTestCase {
     
     func test_verify_state_changes_once_after_many_actions_were_processed() {
         let testScheduler = DispatchQueue.test
-        let store = ARCTestStore(
+        let store = NonExhaustiveTestStore(
             initialState: State(),
             reducer: reducer,
             environment: testScheduler.eraseToAnyScheduler()
@@ -76,7 +76,7 @@ class ARCTestStoreTests: XCTestCase {
     
     func test_verify_received_actions() {
         let testScheduler = DispatchQueue.test
-        let store = ARCTestStore(
+        let store = NonExhaustiveTestStore(
             initialState: State(),
             reducer: reducer,
             environment: testScheduler.eraseToAnyScheduler()


### PR DESCRIPTION
- Minimal changes to original TCA store (access levels, + one func conversion to static) <- so that any upstream updates we need to do are as simple as possible
- Implements non exhaustive `TestStore` based on TCA original one (again thinking about potential upstream updates)
- Adds `TBCTestStore` shim as a replacement for the one we use currently

[Design Doc](https://www.notion.so/browserinc/Custom-TCA-TestStore-3eaa2992f8e14b84ab966cd614bd1057)

**Implementation note:**
I contemplated going with protocol like `TestStoreImplementation` which would just match up interface across both stores (since they match in syntax already) rather than enum switch, but decided not to do because Protocols don't support default arguments which means Shim type is necessary anyway because we want `file`, `line` automation, we'd end up with more code and so I opted out for KISS shim with switch over explicit enum
