### PR TITLE
[REL-142] Remove self refs when getting store types

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -371,7 +371,7 @@ public final class Store<State, Action> {
     self.isSending = true
     var currentState = self.state.value
 
-    let callbackInfo = Instrumentation.CallbackInfo(storeKind: Store<State, Action>.self, action: action, originatingAction: originatingAction).eraseToAny()
+    let callbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: action, originatingAction: originatingAction).eraseToAny()
     instrumentation.callback?(callbackInfo, .pre, .storeSend)
     defer { instrumentation.callback?(callbackInfo, .post, .storeSend) }
 
@@ -392,7 +392,7 @@ public final class Store<State, Action> {
     while !self.bufferedActions.isEmpty {
       let action = self.bufferedActions.removeFirst()
 
-      let processCallbackInfo = Instrumentation.CallbackInfo(storeKind: Store<State,Action>.self, action: action, originatingAction: nil).eraseToAny()
+      let processCallbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: action, originatingAction: nil).eraseToAny()
       instrumentation.callback?(processCallbackInfo, .pre, .storeProcessEvent)
       defer { instrumentation.callback?(processCallbackInfo, .post, .storeProcessEvent) }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -371,7 +371,7 @@ public final class Store<State, Action> {
     self.isSending = true
     var currentState = self.state.value
 
-    let callbackInfo = Instrumentation.CallbackInfo(storeKind: self.self, action: action, originatingAction: originatingAction).eraseToAny()
+    let callbackInfo = Instrumentation.CallbackInfo(storeKind: Store<State, Action>.self, action: action, originatingAction: originatingAction).eraseToAny()
     instrumentation.callback?(callbackInfo, .pre, .storeSend)
     defer { instrumentation.callback?(callbackInfo, .post, .storeSend) }
 
@@ -392,7 +392,7 @@ public final class Store<State, Action> {
     while !self.bufferedActions.isEmpty {
       let action = self.bufferedActions.removeFirst()
 
-      let processCallbackInfo = Instrumentation.CallbackInfo(storeKind: self.self, action: action, originatingAction: nil).eraseToAny()
+      let processCallbackInfo = Instrumentation.CallbackInfo(storeKind: Store<State,Action>.self, action: action, originatingAction: nil).eraseToAny()
       instrumentation.callback?(processCallbackInfo, .pre, .storeProcessEvent)
       defer { instrumentation.callback?(processCallbackInfo, .post, .storeProcessEvent) }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -73,7 +73,7 @@ public final class ViewStore<State, Action>: ObservableObject {
     instrumentation: Instrumentation = .shared
   ) {
     self._send = {
-      let sendCallbackInfo = Instrumentation.CallbackInfo(storeKind: ViewStore<State, Action>.self, action: $0).eraseToAny()
+      let sendCallbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: $0).eraseToAny()
       instrumentation.callback?(sendCallbackInfo, .pre, .viewStoreSend)
       defer { instrumentation.callback?(sendCallbackInfo, .post, .viewStoreSend) }
 
@@ -81,7 +81,7 @@ public final class ViewStore<State, Action>: ObservableObject {
     }
     self._state = CurrentValueRelay(store.state.value)
 
-    let stateChangeCallbackInfo = Instrumentation.CallbackInfo<ViewStore<State, Action>.Type, Action>(storeKind: ViewStore<State, Action>.self).eraseToAny()
+    let stateChangeCallbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: nil as Action?).eraseToAny()
     self.viewCancellable = store.state
       .removeDuplicates(by: {
         instrumentation.callback?(stateChangeCallbackInfo, .pre, .viewStoreDeduplicate)

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -73,7 +73,7 @@ public final class ViewStore<State, Action>: ObservableObject {
     instrumentation: Instrumentation = .shared
   ) {
     self._send = {
-      let sendCallbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: $0).eraseToAny()
+      let sendCallbackInfo = Instrumentation.CallbackInfo(storeKind: ViewStore<State, Action>.self, action: $0).eraseToAny()
       instrumentation.callback?(sendCallbackInfo, .pre, .viewStoreSend)
       defer { instrumentation.callback?(sendCallbackInfo, .post, .viewStoreSend) }
 
@@ -81,7 +81,7 @@ public final class ViewStore<State, Action>: ObservableObject {
     }
     self._state = CurrentValueRelay(store.state.value)
 
-    let stateChangeCallbackInfo = Instrumentation.CallbackInfo<ViewStore<State, Action>, Action>(storeKind: self.self).eraseToAny()
+    let stateChangeCallbackInfo = Instrumentation.CallbackInfo<ViewStore<State, Action>.Type, Action>(storeKind: ViewStore<State, Action>.self).eraseToAny()
     self.viewCancellable = store.state
       .removeDuplicates(by: {
         instrumentation.callback?(stateChangeCallbackInfo, .pre, .viewStoreDeduplicate)


### PR DESCRIPTION
## Description

When attempting to land https://github.com/thebrowsercompany/browser-swift/pull/7142 there was a single test that was failing (`BugReporterTests.testCreateBugReportWithCommandBarRanking`) for what looked like unexpected reasons. As I debugged locally I found that the specific test `AppReducerTests.testItSubscribesToSofwareUpdaterDelegate` was necessary to run _before_ the `testCreateBugReportWithCommandBarRanking` test in order to hit the failure. The failure in question is a reference to an `unowned` object that had already been deallocated. The reference would happen in a `NotificationCenter` observer, specifically for the notification once the bug report is successfully submitted. On main these tests do not fail, so obviously it was related to my change.

I did some experimentation within `browser-swift` and found that I could avoid the failure if I set a cancellation ID on the resulting effect from `AppState.observeBugReporterNotifications` which kind of makes sense: if there was some retain cycle happening and the notification observers were not being removed, then sending those notifications would trigger accessing a deallocated unowned object. However, since this is not happening on main it is not likely that there was a small "tickle" in the timing from the TCA instrumentation change that caused it. The failure was happening 100% when running those two tests.

So I went back to the TCA instrumentation change. After reading it again, it is clear that the usage of `self.self` could lead to retain cycles (and in fact did in the case of the `stateChangeCallbackInfo` value in `ViewStore`). That is because `self.self == self` instead of the type of self. The most straight forward fix is to use `Self.self` which _does_ reference the type as expected.

## Changes
- Use `Self.self` instead of `self.self`

## Test plan
Disable all Browser-UITest methods except the two mentioned above and run those tests. Verify the test does not crash.