### PR TITLE
More informative error message than indexing off the end of an Array.

### DIFF
--- a/Sources/ComposableArchitecture/Injection.swift
+++ b/Sources/ComposableArchitecture/Injection.swift
@@ -161,9 +161,19 @@ extension Reducer {
 
         /// Use callerSymbol/index to retieve closure retaining the reducer function
         func lastStored() -> ReducerFunc {
-            let reducerGetter = reducerOverrideStore[callerSymbol]![index]
-            let anyReducer = reducerGetter(ReducerFunc.self)
-            return anyReducer as! ReducerFunc
+            if let storedReducers = reducerOverrideStore[callerSymbol],
+               let reducerGetter = index < storedReducers.count ?
+                storedReducers[index] : nil, let anyReducer =
+                    reducerGetter(ReducerFunc.self) as? ReducerFunc {
+                return anyReducer
+            } else {
+                fatalError("""
+                    ⚠️ Unable to rerieve injected reducer override for \
+                    \(callerSymbol). Are you sure all top level reducer \
+                    variables composed into this reducer have been wrapped \
+                    in ARCInjectable?
+                    """)
+            }
         }
     }
 }

--- a/Sources/ComposableArchitecture/Injection.swift
+++ b/Sources/ComposableArchitecture/Injection.swift
@@ -168,7 +168,7 @@ extension Reducer {
                 return anyReducer
             } else {
                 fatalError("""
-                    ⚠️ Unable to rerieve injected reducer override for \
+                    ⚠️ Unable to retrieve injected reducer override for \
                     \(callerSymbol). Are you sure all top level reducer \
                     variables composed into this reducer have been wrapped \
                     in ARCInjectable?


### PR DESCRIPTION
Currently if you compose a reducer using another top level variable and it's initialisation is not wrapped in ARCInjectable it is possible to index off the end of the stored reducer table used for overriding reducers during injection. This change adds a more explanatory message about what is causing the problem.