### PR TITLE
Add callback to be able to track ViewStore creation

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -3,6 +3,8 @@ import Foundation
 /// Interface to enable tracking/instrumenting the activity within TCA as ``Actions`` are sent into ``Store``s and
 /// ``ViewStores``, ``Reducers`` are executed, and ``Effects`` are observed.
 ///
+/// Additionally it can also track where `ViewStore` instances's are created.
+///
 /// The way the library will call the closures provided is identical to the way that the ``Actions`` and ``Effects`` are
 /// handled internally. That means that there are likely to be ``Instrumentation.ViewStore`` `will|did` pairs contained
 /// within the bounds of an ``Instrumentation.Store`` `will|did` pair. For example: Consider sending a simple ``Action``
@@ -57,11 +59,16 @@ public class Instrumentation {
   public typealias Callback = (_ info: CallbackInfo<Any, Any>, _ timing: CallbackTiming, _ kind: CallbackKind) -> Void
   let callback: Callback?
 
+  /// Used to track when an instance of a `ViewStore` was created
+  public typealias ViewStoreCreatedCallback = (_ instance: AnyObject, _ file: StaticString, _ line: UInt) -> Void
+  let viewStoreCreated: ViewStoreCreatedCallback?
+
   public static let noop = Instrumentation()
   public static var shared: Instrumentation = .noop
 
-  public init(callback: Callback? = nil) {
+  public init(callback: Callback? = nil, viewStoreCreated: ViewStoreCreatedCallback? = nil) {
     self.callback = callback
+    self.viewStoreCreated = viewStoreCreated
   }
 }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -70,7 +70,9 @@ public final class ViewStore<State, Action>: ObservableObject {
   public init(
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
-    instrumentation: Instrumentation = .shared
+    instrumentation: Instrumentation = .shared,
+    file: StaticString = #file,
+    line: UInt = #line
   ) {
     self._send = {
       let sendCallbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: $0).eraseToAny()
@@ -99,13 +101,16 @@ public final class ViewStore<State, Action>: ObservableObject {
         _state.value = $0
       }
 
+      instrumentation.viewStoreCreated?(self as AnyObject, file, line)
   }
 
-  internal init(_ viewStore: ViewStore<State, Action>, instrumentation: Instrumentation = .shared) {
+  internal init(_ viewStore: ViewStore<State, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {
     self._send = viewStore._send
     self._state = viewStore._state
     self.objectWillChange = viewStore.objectWillChange
     self.viewCancellable = viewStore.viewCancellable
+
+    instrumentation.viewStoreCreated?(self as AnyObject, file, line)
   }
 
   /// A publisher that emits when state changes.
@@ -296,14 +301,14 @@ public final class ViewStore<State, Action>: ObservableObject {
 }
 
 extension ViewStore where State: Equatable {
-  public convenience init(_ store: Store<State, Action>, instrumentation: Instrumentation = .shared) {
-    self.init(store, removeDuplicates: ==, instrumentation: instrumentation)
+  public convenience init(_ store: Store<State, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {
+    self.init(store, removeDuplicates: ==, instrumentation: instrumentation, file: file, line: line)
   }
 }
 
 extension ViewStore where State == Void {
-  public convenience init(_ store: Store<Void, Action>, instrumentation: Instrumentation = .shared) {
-    self.init(store, removeDuplicates: ==, instrumentation: instrumentation)
+  public convenience init(_ store: Store<Void, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {
+    self.init(store, removeDuplicates: ==, instrumentation: instrumentation, file: file, line: line)
   }
 }
 


### PR DESCRIPTION
Adds a callback so I know where (and when) `ViewStore` instances are created