### PR TITLE
Make CallbackKind CaseIterable and Hashable

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -36,7 +36,7 @@ import Foundation
 /// ```
 public class Instrumentation {
   /// Type indicating the action being taken by the store
-  public enum CallbackKind {
+  public enum CallbackKind: CaseIterable, Hashable {
     case storeSend
     case storeChangeState
     case storeProcessEvent


### PR DESCRIPTION
We are extending our instrumentation and I want to be able to use the `CallbackKind` cases as keys in a dictionary and to iterate over all of them. So let's just let the compiler generate these conformances for us.