### PR TITLE
[REL-249] Additional instrumented code

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -38,6 +38,7 @@ public class Instrumentation {
   /// Type indicating the action being taken by the store
   public enum CallbackKind: CaseIterable, Hashable {
     case storeSend
+    case storeToLocal
     case storeChangeState
     case storeProcessEvent
     case viewStoreSend

--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -23,13 +23,23 @@ import Foundation
 ///     The above(willProcess -> didProcess) is repeated for each queued up action within Store
 ///     .pre, .storeChangeState
 ///       The Store updates its state
-///       Any Stores that have been created via scoping off the current Store object will have their states updated at this point too, thus there may be multiple instances of `.pre|.post` `.(view)[sS]toreChangeState` and `.pre|post` `.viewStoreDeduplicate` contained within a `.pre|.post` `.storeChangeState`
-///       .pre, .viewStoreDeduplicate for impacted ViewStores
-///       The existing state of the ViewStore instance is compared newly generated state and determined if it is a duplicate (this is unique to our branch of TCA)
-///       .post, .viewStoreDeduplicate
-///       .pre, .viewStoreChangeState
-///       If the value for a ViewStores state was not a duplicate, then it is updated
-///       .post, .viewStoreChangeState
+///       For each child Store scoped off the Store using a scoped local state
+///         The Store computes the scoped local state
+///         .pre, .storeToLocal
+///         .post, .storeToLocal
+///         The Store determines if the scoped local state is has changed
+///         .pre, .storeDeduplicate
+///         .post, .storeDeduplicate
+///         If the scoped local state has changed then the scoped child Store's state is updated, along with any further
+///         downstream scoped Stores
+///       For each ViewStore subscribed to a Store, if the state has changed will have their states updated at this too,
+///       thus there may be multiple instances of the below
+///         .pre, .viewStoreDeduplicate for impacted ViewStores
+///         The existing state of the ViewStore instance is compared newly generated state and determined if it is a duplicate (this is unique to our branch of TCA)
+///         .post, .viewStoreDeduplicate
+///         .pre, .viewStoreChangeState
+///         If the value for a ViewStores state was not a duplicate, then it is updated
+///         .post, .viewStoreChangeState
 ///     .post, .storeChangeState
 ///   .post, .store.didSend
 /// .post, .viewStoreSend

--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -39,6 +39,7 @@ public class Instrumentation {
   public enum CallbackKind: CaseIterable, Hashable {
     case storeSend
     case storeToLocal
+    case storeDeduplicate
     case storeChangeState
     case storeProcessEvent
     case viewStoreSend

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -375,9 +375,10 @@ public final class Store<State, Action> {
   /// - Parameter toLocalState: A function that transforms `State` into `LocalState`.
   /// - Returns: A new store with its domain (state and action) transformed.
   public func scope<LocalState>(
-    state toLocalState: @escaping (State) -> LocalState
+    state toLocalState: @escaping (State) -> LocalState,
+    instrumentation: Instrumentation = .shared
   ) -> Store<LocalState, Action> {
-    self.scope(state: toLocalState, action: { $0 })
+    self.scope(state: toLocalState, action: { $0 }, instrumentation: instrumentation)
   }
 
   func send(_ action: Action, originatingFrom originatingAction: Action? = nil, instrumentation: Instrumentation = .shared) {


### PR DESCRIPTION
As we dig into where most time is spent we realized it would be great to know how much time was spent in the scoping 
functions (the `toLocalState` code) and in the scoped deduplication. Neither of these were previously instrumented.

# Test Steps
CI
