### PR TITLE
[REL-261] ViewStore initializer for void state

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -124,6 +124,8 @@ public final class ViewStore<State, Action>: ObservableObject {
       store.send($0, instrumentation: instrumentation)
     }
     self._state = CurrentValueRelay(())
+
+    instrumentation.viewStoreCreated?(self as AnyObject, file, line)
   }
 
   internal init(_ viewStore: ViewStore<State, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -104,6 +104,28 @@ public final class ViewStore<State, Action>: ObservableObject {
       instrumentation.viewStoreCreated?(self as AnyObject, file, line)
   }
 
+  /// Initializes a view store from a store that has a state of type void. This special initializer prevents this view
+  /// store from taking part in state propagation for any actions sent since a void state has not value to update.
+  ///
+  /// - Parameters:
+  ///   - store: A store
+  ///   - instrumentation: Instrumentation instance that may be used to trace behavior of this ViewStore
+  public init(
+    _ store: Store<State, Action>,
+    instrumentation: Instrumentation = .shared,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) where State == Void {
+    self._send = {
+      let sendCallbackInfo = Instrumentation.CallbackInfo(storeKind: Self.self, action: $0).eraseToAny()
+      instrumentation.callback?(sendCallbackInfo, .pre, .viewStoreSend)
+      defer { instrumentation.callback?(sendCallbackInfo, .post, .viewStoreSend) }
+
+      store.send($0, instrumentation: instrumentation)
+    }
+    self._state = CurrentValueRelay(())
+  }
+
   internal init(_ viewStore: ViewStore<State, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {
     self._send = viewStore._send
     self._state = viewStore._state
@@ -315,12 +337,6 @@ public final class ViewStore<State, Action>: ObservableObject {
 
 extension ViewStore where State: Equatable {
   public convenience init(_ store: Store<State, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {
-    self.init(store, removeDuplicates: ==, instrumentation: instrumentation, file: file, line: line)
-  }
-}
-
-extension ViewStore where State == Void {
-  public convenience init(_ store: Store<Void, Action>, instrumentation: Instrumentation = .shared, file: StaticString = #file, line: UInt = #line) {
     self.init(store, removeDuplicates: ==, instrumentation: instrumentation, file: file, line: line)
   }
 }


### PR DESCRIPTION
A `ViewStore` that is created from a `Store` with `State == Void` gains little to nothing by subscribing to updates on 
the parent `Store`'s state. Further, in our fork that adds the `removeDuplicates` checks we defaulted to the `==` 
function which will always return `true` for `Void` values, meaning that the updates never made it to the `ViewStore`'s
state and so subscribers (if there were any) would never be updated either.

Within `browser-swift` we currently use the `ViewStore(store.stateless)` pattern exclusively for sending actions back 
into parent stores. This is great and the expected usage but currently we pay for these view stores on the scoping pass
when they are never going to update and have no subscribers. By removing their subscription to their parent store they 
will not take part in anything other than passing sent actions.
