### PR TITLE
[REL-261] WithViewStore special casing for Void state

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -16,7 +16,7 @@ public struct WithViewStore<State, Action, Content> {
 
   fileprivate init(
     store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    viewStore: ViewStore<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
     content: @escaping (ViewStore<State, Action>) -> Content
@@ -31,7 +31,22 @@ public struct WithViewStore<State, Action, Content> {
         return previousState
       }
     #endif
-    self.viewStore = ViewStore(store, removeDuplicates: isDuplicate, file: file, line: line)
+    self.viewStore = viewStore
+  }
+
+  fileprivate init(
+    store: Store<State, Action>,
+    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(
+      store: store,
+      viewStore: ViewStore(store, removeDuplicates: isDuplicate, file: file, line: line),
+      file: file,
+      line: line,
+      content: content)
   }
 
   /// Prints debug information to the console whenever the view is computed.
@@ -139,7 +154,12 @@ extension WithViewStore where State == Void, Content: View {
     line: UInt = #line,
     @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(
+      store: store,
+      viewStore: ViewStore(store, file: file, line: line),
+      file: file,
+      line: line,
+      content: content)
   }
 }
 


### PR DESCRIPTION
We already had an override for the case `where State == Void` but it did
not funnel through to the new `ViewState<Void, Action>` initializer
because we were providing a `removeDuplicates` parameter. To make use of
the new `ViewStore` intializer we can change the designated initializer
to take in the `ViewStore` instead of initializing it directly, and then
for the `State == Void` case we pass in the desired `ViewStore` that
bypasses the deduplication check.

# Test Plan
With this change when using `WithViewStore` in the app we should no 
longer see any `dedup-vs` spans in Sentry.

| Before | After |
| --- | --- |
| ![CleanShot 2022-06-29 at 16 58 04@2x](https://user-images.githubusercontent.com/1282845/176543661-305789a6-46e4-4027-a4d9-690250c53eea.png) | ![CleanShot 2022-06-29 at 16 55 19@2x](https://user-images.githubusercontent.com/1282845/176543216-cbeb018a-8318-4bf0-b195-0951708645e7.png) |
