### PR TITLE
Test store update closures need to be optional

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/NonExhaustiveTestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/NonExhaustiveTestStore.swift
@@ -120,7 +120,7 @@
       _ action: LocalAction,
       file: StaticString = #file,
       line: UInt = #line,
-      _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+      _ update: ((inout LocalState) throws -> Void)? = nil
     ) {
       receivedActions.removeAll() // When developer explicitly sends an action, reset all recorded ones so we can compare from this point in time
       
@@ -140,7 +140,7 @@
       _ action: Action,
       file: StaticString = #file,
       line: UInt = #line,
-      _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+      _ update: ((inout LocalState) throws -> Void)? = nil
     ) {
       guard receivedActions.contains(where: { $0.action == action }) else {
           XCTFail(
@@ -168,7 +168,7 @@
         actionToSend: LocalAction?,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+        _ update: ((inout LocalState) throws -> Void)? = nil
     ) {
         let viewStore = ViewStore(
           self.store.scope(
@@ -186,7 +186,9 @@
         var stateAfterApplyingUpdate = stateAfterReducerApplication
 
         do {
-          try update(&stateAfterApplyingUpdate)
+          if let update = update {
+            try update(&stateAfterApplyingUpdate)
+          }
           try TCATestStoreType.expectedStateShouldMatch(
             expected: &stateAfterApplyingUpdate,
             actual: stateAfterReducerApplication,

--- a/Sources/ComposableArchitecture/TestSupport/TBCTestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TBCTestStore.swift
@@ -108,7 +108,7 @@ extension TBCTestStore where LocalState: Equatable {
         _ action: LocalAction,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+        _ update: ((inout LocalState) throws -> Void)? = nil
     ) {
         switch storeImplementation {
         case let .exhaustive(store):
@@ -124,7 +124,7 @@ extension TBCTestStore where LocalState: Equatable, Action: Equatable {
         _ expectedAction: Action,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
+        _ update: ((inout LocalState) throws -> Void)? = nil
     ) {
         switch storeImplementation {
         case let .exhaustive(store):


### PR DESCRIPTION
Upstream TCA updated their test stores to take optional update closures and then assert on if the closure exists the 
state _must_ have been updated. Our TBCTestStore was unconditionally passing a closure along (though the default was 
doing nothing) so this simply converts to having an optional value that defaults to `nil`.

See https://github.com/thebrowsercompany/browser-swift/actions/runs/2584426148 for failures on main that will happen

# Test Plan
- Update `browser-swift` to reference the current head of `develop` branch and build `AppReducerTests.testASEIndexTrigger` and notice it fails with the following failures

```
/Users/amonshiz/Developer/browser-swift-1/BrowserTests/AppReducerTests/AppReducerTests.swift:25: error: -[BrowserTests.AppReducerTests testASEIndexTrigger] : Expected state to change, but no change occurred.

The trailing closure made no observable modifications to state. If no change to state is expected, omit the trailing closure.
/Users/amonshiz/Developer/browser-swift-1/BrowserTests/AppReducerTests/AppReducerTests.swift:27: error: -[BrowserTests.AppReducerTests testASEIndexTrigger] : Expected state to change, but no change occurred.

The trailing closure made no observable modifications to state. If no change to state is expected, omit the trailing closure.
/Users/amonshiz/Developer/browser-swift-1/BrowserTests/AppReducerTests/AppReducerTests.swift:28: error: -[BrowserTests.AppReducerTests testASEIndexTrigger] : Expected state to change, but no change occurred.

The trailing closure made no observable modifications to state. If no change to state is expected, omit the trailing closure.
```

- Pull this PR and run same test with appropriately updated Package.swift and notice it passes
