### PR TITLE
Instrumention around a scoped store's state update

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -25,13 +25,15 @@ import Foundation
 ///       The Store updates its state
 ///       For each child Store scoped off the Store using a scoped local state
 ///         The Store computes the scoped local state
-///         .pre, .storeToLocal
-///         .post, .storeToLocal
+///         .pre, .scopedscopedStoreToLocal
+///         .post, .scopedscopedStoreToLocal
 ///         The Store determines if the scoped local state is has changed
-///         .pre, .storeDeduplicate
-///         .post, .storeDeduplicate
+///         .pre, .scopedStoreDeduplicate
+///         .post, .scopedtoreDeduplicate
 ///         If the scoped local state has changed then the scoped child Store's state is updated, along with any further
 ///         downstream scoped Stores
+///         .pre, .scopedStoreChangeState
+///         .post, .scopedStoreChangeState
 ///       For each ViewStore subscribed to a Store, if the state has changed will have their states updated at this too,
 ///       thus there may be multiple instances of the below
 ///         .pre, .viewStoreDeduplicate for impacted ViewStores
@@ -48,10 +50,11 @@ public class Instrumentation {
   /// Type indicating the action being taken by the store
   public enum CallbackKind: CaseIterable, Hashable {
     case storeSend
-    case storeToLocal
-    case storeDeduplicate
     case storeChangeState
     case storeProcessEvent
+    case scopedStoreToLocal
+    case scopedStoreDeduplicate
+    case scopedStoreChangeState
     case viewStoreSend
     case viewStoreChangeState
     case viewStoreDeduplicate

--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -25,8 +25,8 @@ import Foundation
 ///       The Store updates its state
 ///       For each child Store scoped off the Store using a scoped local state
 ///         The Store computes the scoped local state
-///         .pre, .scopedscopedStoreToLocal
-///         .post, .scopedscopedStoreToLocal
+///         .pre, .scopedStoreToLocal
+///         .post, .scopedStoreToLocal
 ///         The Store determines if the scoped local state is has changed
 ///         .pre, .scopedStoreDeduplicate
 ///         .post, .scopedtoreDeduplicate

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -350,21 +350,25 @@ public final class Store<State, Action> {
         guard !isSending else { return }
 
         let callbackInfo = Instrumentation.CallbackInfo<Store<LocalState, LocalAction>.Type, Any>(storeKind: Store<LocalState, LocalAction>.self, action: nil, file: file, line: line).eraseToAny()
-        instrumentation.callback?(callbackInfo, .pre, .storeToLocal)
+        instrumentation.callback?(callbackInfo, .pre, .scopedStoreToLocal)
         let newLocalState = toLocalState(newValue)
-        instrumentation.callback?(callbackInfo, .post, .storeToLocal)
+        instrumentation.callback?(callbackInfo, .post, .scopedStoreToLocal)
 
         guard let previousState = localStore?.state.value, let isDuplicate = isDuplicate else {
+            instrumentation.callback?(callbackInfo, .pre, .scopedStoreChangeState)
             localStore?.state.value = newLocalState
+            instrumentation.callback?(callbackInfo, .post, .scopedStoreChangeState)
             return
         }
 
-        instrumentation.callback?(callbackInfo, .pre, .storeDeduplicate)
+        instrumentation.callback?(callbackInfo, .pre, .scopedStoreDeduplicate)
         let newStateIsDuplicate = isDuplicate(newLocalState, previousState)
-        instrumentation.callback?(callbackInfo, .post, .storeDeduplicate)
+        instrumentation.callback?(callbackInfo, .post, .scopedStoreDeduplicate)
 
         if !newStateIsDuplicate {
+            instrumentation.callback?(callbackInfo, .pre, .scopedStoreChangeState)
             localStore?.state.value = newLocalState
+            instrumentation.callback?(callbackInfo, .post, .scopedStoreChangeState)
         }
       }
     return localStore

--- a/Tests/ComposableArchitectureTests/InstrumentationTests.swift
+++ b/Tests/ComposableArchitectureTests/InstrumentationTests.swift
@@ -20,7 +20,7 @@ final class InstrumentationTests: XCTestCase {
         changeStateCalls += 1
       case (_, .storeProcessEvent):
         processCalls += 1
-      case (_, .storeToLocal), (_, .storeDeduplicate):
+      case (_, .scopedStoreToLocal), (_, .scopedStoreDeduplicate), (_, .scopedStoreChangeState):
         XCTFail("Scope based callbacks should not be called")
       }
     })
@@ -56,7 +56,7 @@ final class InstrumentationTests: XCTestCase {
         dedupCalls_vs += 1
       case (_, .viewStoreChangeState):
         changeCalls_vs += 1
-      case (_, .storeToLocal), (_, .storeDeduplicate):
+      case (_, .scopedStoreToLocal), (_, .scopedStoreDeduplicate), (_, .scopedStoreChangeState):
         XCTFail("Scope based callbacks should not be called")
       }
     })
@@ -94,7 +94,7 @@ final class InstrumentationTests: XCTestCase {
         XCTFail("View store deduplicate callback should not be called")
       case (_, .viewStoreChangeState):
         XCTFail("View store state change callback should not be called")
-      case (_, .storeToLocal), (_, .storeDeduplicate):
+      case (_, .scopedStoreToLocal), (_, .scopedStoreDeduplicate), (_, .scopedStoreChangeState):
         XCTFail("Scope based callbacks should not be called")
       }
     })
@@ -132,7 +132,7 @@ final class InstrumentationTests: XCTestCase {
         dedupCalls_vs += 1
       case (_, .viewStoreChangeState):
         changeCalls_vs += 1
-      case (_, .storeToLocal), (_, .storeDeduplicate):
+      case (_, .scopedStoreToLocal), (_, .scopedStoreDeduplicate), (_, .scopedStoreChangeState):
         XCTFail("Scope based callbacks should not be called")
       }
     })
@@ -179,7 +179,7 @@ final class InstrumentationTests: XCTestCase {
         dedupCalls_vs += 1
       case (_, .viewStoreChangeState):
         changeCalls_vs += 1
-      case (_, .storeToLocal), (_, .storeDeduplicate):
+      case (_, .scopedStoreToLocal), (_, .scopedStoreDeduplicate), (_, .scopedStoreChangeState):
         XCTFail("Scope based callbacks should not be called")
       }
     })
@@ -221,8 +221,9 @@ final class InstrumentationTests: XCTestCase {
     var sendCalls_s = 0
     var changeStateCalls_s = 0
     var processCalls_s = 0
-    var dedupeCalls_s = 0
-    var toLocalCalls_s = 0
+    var scopedDedupeCalls_s = 0
+    var scopedToLocalCalls_s = 0
+    var scopedChangeStateCalls_s: Int = 0
 
     let inst = ComposableArchitecture.Instrumentation(callback: { info, timing, kind in
       switch (timing, kind) {
@@ -238,10 +239,12 @@ final class InstrumentationTests: XCTestCase {
         dedupCalls_vs += 1
       case (_, .viewStoreChangeState):
         changeCalls_vs += 1
-      case (_, .storeToLocal):
-        toLocalCalls_s += 1
-      case (_, .storeDeduplicate):
-        dedupeCalls_s += 1
+      case (_, .scopedStoreToLocal):
+        scopedToLocalCalls_s += 1
+      case (_, .scopedStoreDeduplicate):
+        scopedDedupeCalls_s += 1
+      case (_, .scopedStoreChangeState):
+        scopedChangeStateCalls_s += 1
       }
     })
 
@@ -268,9 +271,10 @@ final class InstrumentationTests: XCTestCase {
     XCTAssertEqual(2, sendCalls_s)
     XCTAssertEqual(2, changeStateCalls_s)
     XCTAssertEqual(2, processCalls_s)
-    XCTAssertEqual(2, toLocalCalls_s)
+    XCTAssertEqual(2, scopedToLocalCalls_s)
     // There was no deduplication function defined
-    XCTAssertEqual(0, dedupeCalls_s)
+    XCTAssertEqual(0, scopedDedupeCalls_s)
+    XCTAssertEqual(2, scopedChangeStateCalls_s)
   }
 
   func testScopedStore_WithDedup() {
@@ -280,8 +284,9 @@ final class InstrumentationTests: XCTestCase {
     var sendCalls_s = 0
     var changeStateCalls_s = 0
     var processCalls_s = 0
-    var dedupeCalls_s = 0
-    var toLocalCalls_s = 0
+    var scopedDedupeCalls_s = 0
+    var scopedToLocalCalls_s = 0
+    var scopedChangeStateCalls_s: Int = 0
 
     let inst = ComposableArchitecture.Instrumentation(callback: { info, timing, kind in
       switch (timing, kind) {
@@ -297,10 +302,12 @@ final class InstrumentationTests: XCTestCase {
         dedupCalls_vs += 1
       case (_, .viewStoreChangeState):
         changeCalls_vs += 1
-      case (_, .storeToLocal):
-        toLocalCalls_s += 1
-      case (_, .storeDeduplicate):
-        dedupeCalls_s += 1
+      case (_, .scopedStoreToLocal):
+        scopedToLocalCalls_s += 1
+      case (_, .scopedStoreDeduplicate):
+        scopedDedupeCalls_s += 1
+      case (_, .scopedStoreChangeState):
+        scopedChangeStateCalls_s += 1
       }
     })
 
@@ -333,8 +340,9 @@ final class InstrumentationTests: XCTestCase {
     XCTAssertEqual(2, changeStateCalls_s)
     XCTAssertEqual(2, processCalls_s)
     // Initial value then update
-    XCTAssertEqual(2, toLocalCalls_s)
-    XCTAssertEqual(2, dedupeCalls_s)
+    XCTAssertEqual(2, scopedToLocalCalls_s)
+    XCTAssertEqual(2, scopedDedupeCalls_s)
+    XCTAssertEqual(2, scopedChangeStateCalls_s)
   }
 
   func test_tracks_viewStore_creation() {


### PR DESCRIPTION
As discussed on Slack there appears to be a little more data missing. We were 
not instrumenting the time it takes for a scoped store to update its own local 
state.

Originally I had left this off based on the mistaken belief that if a scoped 
store did not have a ViewStore observing it then there was not going to be any 
real cost or need to see time spent. But, since there can be an unlimited number
of scoped stores in existence that do not have any ViewStores off of them, this
_could_ get relatively costly.

## Changes
- Add new instrumentation `kind`
- Place instrumentation around scoped store's updating their state using new kind
- Update tests to account for new kind

## Test plan
Unit tests and integration into Arc
