### PR TITLE
let's attribute time spent for to_local to the store taking the time

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -349,7 +349,7 @@ public final class Store<State, Action> {
       .sink { [weak localStore] newValue in
         guard !isSending else { return }
 
-        let callbackInfo = Instrumentation.CallbackInfo<Self.Type, Any>(storeKind: Self.self, action: nil, file: file, line: line).eraseToAny()
+        let callbackInfo = Instrumentation.CallbackInfo<Store<LocalState, LocalAction>.Type, Any>(storeKind: Store<LocalState, LocalAction>.self, action: nil, file: file, line: line).eraseToAny()
         instrumentation.callback?(callbackInfo, .pre, .storeToLocal)
         let newLocalState = toLocalState(newValue)
         instrumentation.callback?(callbackInfo, .post, .storeToLocal)


### PR DESCRIPTION
... instead of its parent (it can't do anything about it)

Previously, our Dashboard would attribute to the time of scoping to the parent's store. Let's not do that - this provides the wrong signal where to optimize / issues might be.