### PR TITLE
Make CallbackKind a String backed enum

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -48,7 +48,7 @@ import Foundation
 /// ```
 public class Instrumentation {
   /// Type indicating the action being taken by the store
-  public enum CallbackKind: CaseIterable, Hashable {
+  public enum CallbackKind: String, CaseIterable, Hashable {
     case storeSend
     case storeChangeState
     case storeProcessEvent


### PR DESCRIPTION
Got feedback that our usage would be cleaned up if this enum were String backed since we could then use the `rawValue`. Simple enough to do!
