### PR TITLE
Track missing toLocal cost

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -334,12 +334,16 @@ public final class Store<State, Action> {
     self.threadCheck(status: .scope)
     var isSending = false
     let localStore = Store<LocalState, LocalAction>(
-      initialState: toLocalState(self.state.value),
+      initialState: toLocalState(self.state.value), // we don't track this one but it's only once per scope function so neglible cost
       reducer: .init { localState, localAction, _ in
         isSending = true
         defer { isSending = false }
         self.send(fromLocalAction(localAction), file: file, line: line)
+        let callbackInfo = Instrumentation.CallbackInfo<Store<LocalState, LocalAction>.Type, Any>(storeKind: Store<LocalState, LocalAction>.self, action: localAction, file: file, line: line).eraseToAny()
+        instrumentation.callback?(callbackInfo, .pre, .scopedStoreToLocal)
         localState = toLocalState(self.state.value)
+        instrumentation.callback?(callbackInfo, .post, .scopedStoreToLocal)
+
         return .none
       },
       environment: ()


### PR DESCRIPTION
Tracks the missing toLocal cost we pay for each child action coming from the store