### PR TITLE
[PLIN-201] Inject instrumentation on root store and add method to change callbacks during execution

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -72,16 +72,27 @@ public class Instrumentation {
   /// - Parameter timing: When this callback is being invoked (pre|post)
   /// - Parameter kind: The store's activity that to which this callback relates (state update, deduplication, etc)
   public typealias Callback = (_ info: CallbackInfo<Any, Any>, _ timing: CallbackTiming, _ kind: CallbackKind) -> Void
-  let callback: Callback?
+  var callback: Callback?
 
-  /// Used to track when an instance of a `ViewStore` was created
+  /// Used to track when/where an instance of a `ViewStore` was create
   public typealias ViewStoreCreatedCallback = (_ instance: AnyObject, _ file: StaticString, _ line: UInt) -> Void
-  let viewStoreCreated: ViewStoreCreatedCallback?
+  var viewStoreCreated: ViewStoreCreatedCallback?
 
   public static let noop = Instrumentation()
-  public static var shared: Instrumentation = .noop
 
   public init(callback: Callback? = nil, viewStoreCreated: ViewStoreCreatedCallback? = nil) {
+    self.callback = callback
+    self.viewStoreCreated = viewStoreCreated
+  }
+
+
+  /// Used to update the instance with new callbacks. This needs to be used _only_ on the same queue as the root ``Store``
+  /// instance.
+  /// - Parameters:
+  ///   - callback: The callback invoked during the "life cycle" of the various stores within the app as an action is
+  ///   acted upon.
+  ///   - viewStoreCreated: Used to track when/where an instance of a ``ViewStore`` was created
+  public func update(callback: Callback? = nil, viewStoreCreated: ViewStoreCreatedCallback? = nil) {
     self.callback = callback
     self.viewStoreCreated = viewStoreCreated
   }

--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -72,11 +72,11 @@ public class Instrumentation {
   /// - Parameter timing: When this callback is being invoked (pre|post)
   /// - Parameter kind: The store's activity that to which this callback relates (state update, deduplication, etc)
   public typealias Callback = (_ info: CallbackInfo<Any, Any>, _ timing: CallbackTiming, _ kind: CallbackKind) -> Void
-  var callback: Callback?
+  private(set) var callback: Callback?
 
   /// Used to track when/where an instance of a `ViewStore` was create
   public typealias ViewStoreCreatedCallback = (_ instance: AnyObject, _ file: StaticString, _ line: UInt) -> Void
-  var viewStoreCreated: ViewStoreCreatedCallback?
+  private(set) var viewStoreCreated: ViewStoreCreatedCallback?
 
   public static let noop = Instrumentation()
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -430,7 +430,8 @@ extension Store {
               return .none
             }
           },
-          environment: ()
+          environment: (),
+          instrumentation: self.instrumentation
         )
 
         localStore.parentCancellable = self.state

--- a/Sources/ComposableArchitecture/NonExhaustiveTestStore.swift
+++ b/Sources/ComposableArchitecture/NonExhaustiveTestStore.swift
@@ -63,7 +63,8 @@
             .eraseToEffect()
 
         },
-        environment: ()
+        environment: (),
+        instrumentation: .noop
       )
     }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -133,6 +133,8 @@ public final class Store<State, Action> {
     private let mainThreadChecksEnabled: Bool
   #endif
 
+  let instrumentation: Instrumentation
+
   /// Initializes a store from an initial state, a reducer, and an environment.
   ///
   /// - Parameters:
@@ -142,15 +144,39 @@ public final class Store<State, Action> {
   public convenience init<Environment>(
     initialState: State,
     reducer: Reducer<State, Action, Environment>,
-    environment: Environment
+    environment: Environment,
+    instrumentation: Instrumentation = .noop
   ) {
     self.init(
       initialState: initialState,
       reducer: reducer,
       environment: environment,
-      mainThreadChecksEnabled: true
+      mainThreadChecksEnabled: true,
+      instrumentation: instrumentation
     )
     self.threadCheck(status: .`init`)
+  }
+
+  /// Initializes a store from an initial state, a reducer, and an environment, and the main thread
+  /// check is disabled for all interactions with this store.
+  ///
+  /// - Parameters:
+  ///   - initialState: The state to start the application in.
+  ///   - reducer: The reducer that powers the business logic of the application.
+  ///   - environment: The environment of dependencies for the application.
+  public static func unchecked<Environment>(
+    initialState: State,
+    reducer: Reducer<State, Action, Environment>,
+    environment: Environment,
+    instrumentation: Instrumentation = .noop
+  ) -> Self {
+    Self(
+      initialState: initialState,
+      reducer: reducer,
+      environment: environment,
+      mainThreadChecksEnabled: false,
+      instrumentation: instrumentation
+    )
   }
 
   /// Scopes the store to one that exposes local state and actions.
@@ -298,8 +324,7 @@ public final class Store<State, Action> {
     action fromLocalAction: @escaping (LocalAction) -> Action,
     removeDuplicates isDuplicate: ((LocalState, LocalState) -> Bool)? = nil,
     file: StaticString = #file,
-    line: UInt = #line,
-    instrumentation: Instrumentation = .shared
+    line: UInt = #line
   ) -> Store<LocalState, LocalAction> {
     self.threadCheck(status: .scope)
     var isSending = false
@@ -310,20 +335,21 @@ public final class Store<State, Action> {
         defer { isSending = false }
         let task = self.send(fromLocalAction(localAction), file: file, line: line)
         let callbackInfo = Instrumentation.CallbackInfo<Store<LocalState, LocalAction>.Type, Any>(storeKind: Store<LocalState, LocalAction>.self, action: localAction, file: file, line: line).eraseToAny()
-        instrumentation.callback?(callbackInfo, .pre, .scopedStoreToLocal)
+        self.instrumentation.callback?(callbackInfo, .pre, .scopedStoreToLocal)
         localState = toLocalState(self.state.value)
-        instrumentation.callback?(callbackInfo, .post, .scopedStoreToLocal)
+        self.instrumentation.callback?(callbackInfo, .post, .scopedStoreToLocal)
         if let task = task {
           return .fireAndForget { await task.cancellableValue }
         } else {
           return .none
         }
       },
-      environment: ()
+      environment: (),
+      instrumentation: instrumentation
     )
     localStore.parentCancellable = self.state
       .dropFirst()
-      .sink { [weak localStore] newValue in
+      .sink { [weak localStore, instrumentation = instrumentation] newValue in
         guard !isSending else { return }
 
         let callbackInfo = Instrumentation.CallbackInfo<Store<LocalState, LocalAction>.Type, Any>(storeKind: Store<LocalState, LocalAction>.self, action: nil, file: file, line: line).eraseToAny()
@@ -360,18 +386,16 @@ public final class Store<State, Action> {
   public func scope<LocalState>(
     state toLocalState: @escaping (State) -> LocalState,
     file: StaticString = #file,
-    line: UInt = #line,
-    instrumentation: Instrumentation = .shared
+    line: UInt = #line
   ) -> Store<LocalState, Action> {
-      self.scope(state: toLocalState, action: { $0 }, file: file, line: line, instrumentation: instrumentation)
+      self.scope(state: toLocalState, action: { $0 }, file: file, line: line)
   }
 
   func send(
     _ action: Action,
     originatingFrom originatingAction: Action? = nil,
     file: StaticString = #file,
-    line: UInt = #line,
-    instrumentation: Instrumentation = .shared
+    line: UInt = #line
   ) -> Task<Void, Never>? {
     self.threadCheck(status: .send(action, originatingAction: originatingAction))
 
@@ -432,7 +456,7 @@ public final class Store<State, Action> {
           },
           receiveValue: { [weak self] effectAction in
             guard let self = self else { return }
-            if let task = self.send(effectAction, originatingFrom: action, file: file, line: line, instrumentation: instrumentation) {
+            if let task = self.send(effectAction, originatingFrom: action, file: file, line: line) {
               tasks.wrappedValue.append(task)
             }
           }
@@ -574,10 +598,12 @@ public final class Store<State, Action> {
     initialState: State,
     reducer: Reducer<State, Action, Environment>,
     environment: Environment,
-    mainThreadChecksEnabled: Bool
+    mainThreadChecksEnabled: Bool,
+    instrumentation: Instrumentation = .noop
   ) {
     self.state = CurrentValueSubject(initialState)
     self.reducer = { state, action in reducer.run(&state, action, environment) }
+    self.instrumentation = instrumentation
 
     #if DEBUG
       self.mainThreadChecksEnabled = mainThreadChecksEnabled

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -133,7 +133,7 @@ public final class Store<State, Action> {
     private let mainThreadChecksEnabled: Bool
   #endif
 
-  let instrumentation: Instrumentation
+  public let instrumentation: Instrumentation
 
   /// Initializes a store from an initial state, a reducer, and an environment.
   ///

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -10,7 +10,7 @@ final class MemoryManagementTests: XCTestCase {
       state += 1
       return .none
     }
-    let store = Store(initialState: 0, reducer: counterReducer, environment: ())
+      let store = Store(initialState: 0, reducer: counterReducer, environment: (), instrumentation: .noop)
       .scope(state: { "\($0)" })
       .scope(state: { Int($0)! })
     let viewStore = ViewStore(store)
@@ -28,7 +28,7 @@ final class MemoryManagementTests: XCTestCase {
       state += 1
       return .none
     }
-    let viewStore = ViewStore(Store(initialState: 0, reducer: counterReducer, environment: ()))
+      let viewStore = ViewStore(Store(initialState: 0, reducer: counterReducer, environment: (), instrumentation: .noop))
 
     var count = 0
     viewStore.publisher.sink { count = $0 }.store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -176,7 +176,8 @@ final class ReducerTests: XCTestCase {
       Store(
         initialState: .init(),
         reducer: reducer,
-        environment: ()
+        environment: (),
+        instrumentation: .noop
       )
     )
     viewStore.send(.incrWithBool(true))


### PR DESCRIPTION
The instrumentation has proven to be extremely beneficial to our team
when attempting to address performance issues. However, it kind of
spread like a weed through the API surface of TCA when it could have
simply been injected into the root Store and been fine. The original
reason for not being injected to the root Store was that the system did
not really support updating the callbacks after the root Store was
created.

After chatting with others it seems like there is little chance of any
inconsistencies in data being introduced by updating the instrumentation
callbacks after the root Store is initialized. The reason is that since
the Store is fully main thread affined it should be safe to update the
callbacks on the main thread. By doing this, generally using
`DispatchQueue.main.async` to be outside the TCA system, there is no
chance that a reference to the Instrumentation will be accessed during
the callback changes and thus there should be no data races.

## Test Plan
Ran the unit tests. They passed in general. The only changes were due to
the slight difference in instrumentation life time in the tests.
Previously the instrumentation was injected on derived view stores and
so would only receive the events that could happen from calling
`ViewStore.send`. Now, though, the instrumentation is added to the
"root" store of the test methods and can, in a few of the tests, receive
more `kind`s than it did before. Those changes are expected.
