### PR TITLE
async non exhaustive teststore

### DIFF
--- a/Sources/ComposableArchitecture/NonExhaustiveTestStore.swift
+++ b/Sources/ComposableArchitecture/NonExhaustiveTestStore.swift
@@ -6,7 +6,9 @@
   final class NonExhaustiveTestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
     typealias TCATestStoreType = TestStore<State, LocalState, Action, LocalAction, Environment>
     var environment: Environment
+    public var timeout: UInt64 = NSEC_PER_SEC
 
+    private let effectDidSubscribe = AsyncStream<Void>.streamWithContinuation()
     private let file: StaticString
     private let fromLocalAction: (LocalAction) -> Action
     private var line: UInt
@@ -36,7 +38,11 @@
 
       self.store = Store(
         initialState: initialState,
-        reducer: Reducer<State, TCATestStoreType.TestAction, Void> { [unowned self] state, action, _ in
+        reducer: Reducer<State, TCATestStoreType.TestAction, Void> { [weak self] state, action, _ in
+          guard let self = self else {
+            XCTFail("Received an action after store was \(Self.self) was already gone.")
+            return .none
+          }
           let effects: Effect<Action, Never>
           switch action.origin {
           case let .send(localAction):
@@ -49,19 +55,28 @@
             self.receivedActions.append((action, state))
           }
 
-          let effect = TCATestStoreType.LongLivingEffect(file: action.file, line: action.line)
-          return
-            effects
-            .handleEvents(
-              receiveSubscription: { [weak self] _ in
-                self?.longLivingEffects.insert(effect)
-              },
-              receiveCompletion: { [weak self] _ in self?.longLivingEffects.remove(effect) },
-              receiveCancel: { [weak self] in self?.longLivingEffects.remove(effect) }
-            )
-            .map { .init(origin: .receive($0), file: action.file, line: action.line) }
-            .eraseToEffect()
+          switch effects.operation {
+          case .none:
+            self.effectDidSubscribe.continuation.yield()
+            return .none
 
+          case .publisher, .run:
+            let effect = TCATestStoreType.LongLivingEffect(file: action.file, line: action.line)
+            return effects
+              .handleEvents(
+                receiveSubscription: { [effectDidSubscribe = self.effectDidSubscribe, weak self] _ in
+                  self?.longLivingEffects.insert(effect)
+                  Task {
+                    await Task.megaYield()
+                    effectDidSubscribe.continuation.yield()
+                  }
+                },
+                receiveCompletion: { [weak self] _ in self?.longLivingEffects.remove(effect) },
+                receiveCancel: { [weak self] in self?.longLivingEffects.remove(effect) }
+              )
+              .map { .init(origin: .receive($0), file: action.file, line: action.line) }
+              .eraseToEffect()
+          }
         },
         environment: (),
         instrumentation: .noop
@@ -117,33 +132,127 @@
   }
 
   extension NonExhaustiveTestStore where LocalState: Equatable {
+    @MainActor
     @discardableResult
     internal func send(
       _ action: LocalAction,
+      _ update: ((inout LocalState) throws -> Void)? = nil,
       file: StaticString = #file,
-      line: UInt = #line,
-      _ update: ((inout LocalState) throws -> Void)? = nil
+      line: UInt = #line
+    ) async -> ViewStoreTask {
+      let task =  { send(action, update, file: file, line: line) }()
+      await Task.megaYield(count: 20)
+      return task
+    }
+
+    @discardableResult
+    @available(iOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(macOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(tvOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(watchOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    internal func send(
+      _ action: LocalAction,
+      _ update: ((inout LocalState) throws -> Void)? = nil,
+      file: StaticString = #file,
+      line: UInt = #line
     ) -> ViewStoreTask {
       receivedActions.removeAll() // When developer explicitly sends an action, reset all recorded ones so we can compare from this point in time
-      
+
       let task = verifyUpdateBlockMatchesState(
           actionToSend: action,
           file: file,
           line: line,
           update
       )
- 
+
       if "\(self.file)" == "\(file)" {
         self.line = line
       }
       return task!
     }
-    
+
+    /// Asserts an action was received from an effect and asserts how the state changes.
+    ///
+    /// - Parameters:
+    ///   - expectedAction: An action expected from an effect.
+    ///   - timeout: The amount of time to wait for the expected action.
+    ///   - updateExpectingResult: A closure that asserts state changed by sending the action to the
+    ///     store. The mutable state sent to this closure must be modified to match the state of the
+    ///     store after processing the given action. Do not provide a closure if no change is
+    ///     expected.
+    @MainActor
+    func receive(
+      _ expectedAction: Action,
+      timeout nanoseconds: UInt64? = nil,
+      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) async {
+      let nanoseconds = nanoseconds ?? self.timeout
+
+      guard !self.longLivingEffects.isEmpty
+      else {
+        { self.receive(expectedAction, updateExpectingResult, file: file, line: line) }()
+        return
+      }
+
+      await Task.megaYield()
+      let start = DispatchTime.now().uptimeNanoseconds
+      while !Task.isCancelled {
+        await Task.detached(priority: .low) { await Task.yield() }.value
+
+        guard self.receivedActions.isEmpty
+        else { break }
+
+        guard start.distance(to: DispatchTime.now().uptimeNanoseconds) < nanoseconds
+        else {
+          let suggestion: String
+          if self.longLivingEffects.isEmpty {
+            suggestion = """
+              There are no in-flight effects that could deliver this action. Could the effect you \
+              expected to deliver this action have been cancelled?
+              """
+          } else {
+            let timeoutMessage =
+              nanoseconds != self.timeout
+              ? #"try increasing the duration of this assertion's "timeout""#
+              : #"configure this assertion with an explicit "timeout""#
+            suggestion = """
+              There are effects in-flight. If the effect that delivers this action uses a \
+              scheduler (via "receive(on:)", "delay", "debounce", etc.), make sure that you wait \
+              enough time for the scheduler to perform the effect. If you are using a test \
+              scheduler, advance the scheduler so that the effects may complete, or consider using \
+              an immediate scheduler to immediately perform the effect instead.
+
+              If you are not yet using a scheduler, or can not use a scheduler, \(timeoutMessage).
+              """
+          }
+          XCTFail(
+            """
+            Expected to receive an action, but received none\
+            \(nanoseconds > 0 ? " after \(Double(nanoseconds)/Double(NSEC_PER_SEC)) seconds" : "").
+
+            \(suggestion)
+            """,
+            file: file,
+            line: line
+          )
+          return
+        }
+      }
+
+      guard !Task.isCancelled
+      else { return }
+
+      { self.receive(expectedAction, updateExpectingResult, file: file, line: line) }()
+      await Task.megaYield()
+    }
+
     internal func receive(
       _ action: Action,
+      _ update: ((inout LocalState) throws -> Void)? = nil,
       file: StaticString = #file,
-      line: UInt = #line,
-      _ update: ((inout LocalState) throws -> Void)? = nil
+      line: UInt = #line
     ) {
       guard receivedActions.contains(where: { $0.action == action }) else {
           XCTFail(
@@ -202,6 +311,47 @@
           XCTFail("Threw error: \(error)", file: file, line: line)
         }
         return task
+    }
+
+    // NB: Only needed until Xcode ships a macOS SDK that uses the 5.7 standard library.
+    // See: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/15
+    #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
+      /// Suspends until all in-flight effects have finished, or until it times out.
+      ///
+      /// Can be used to assert that all effects have finished.
+      ///
+      /// - Parameter duration: The amount of time to wait before asserting.
+      @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+      @MainActor
+      public func finish(
+        timeout duration: Duration? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+      ) async {
+        await self.finish(timeout: duration?.nanoseconds, file: file, line: line)
+      }
+    #endif
+
+    /// Suspends until all in-flight effects have finished, or until it times out.
+    ///
+    /// Can be used to assert that all effects have finished.
+    ///
+    /// - Parameter nanoseconds: The amount of time to wait before asserting.
+    @_disfavoredOverload
+    @MainActor
+    func finish(
+      timeout nanoseconds: UInt64? = nil,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) async {
+      let nanoseconds = nanoseconds ?? self.timeout
+      let start = DispatchTime.now().uptimeNanoseconds
+      await Task.megaYield()
+      while !self.longLivingEffects.isEmpty {
+        guard start.distance(to: DispatchTime.now().uptimeNanoseconds) < nanoseconds
+        else { return }
+        await Task.megaYield()
+      }
     }
   }
 

--- a/Sources/ComposableArchitecture/TBCTestStore.swift
+++ b/Sources/ComposableArchitecture/TBCTestStore.swift
@@ -113,7 +113,7 @@ extension TBCTestStore where LocalState: Equatable {
         case let .exhaustive(store):
             store.send(action, update, file: file, line: line)
         case let .nonExhaustive(store):
-            store.send(action, file: file, line: line, update)
+            store.send(action, update, file: file, line: line)
         }
     }
 
@@ -129,7 +129,7 @@ extension TBCTestStore where LocalState: Equatable {
         case let .exhaustive(store):
             return await TBCTestStoreTask(store.send(action, update, file: file, line: line))
         case let .nonExhaustive(store):
-            return TBCTestStoreTask(store.send(action, file: file, line: line, update))
+            return await TBCTestStoreTask(store.send(action, update, file: file, line: line))
         }
     }
 
@@ -142,8 +142,8 @@ extension TBCTestStore where LocalState: Equatable {
         switch storeImplementation {
         case let .exhaustive(store):
             return await store.finish(timeout: nanoseconds, file: file, line: line)
-        case .nonExhaustive:
-            return
+        case let .nonExhaustive(store):
+            return await store.finish(timeout: nanoseconds, file: file, line: line)
         }
     }
 }
@@ -179,7 +179,7 @@ extension TBCTestStore where LocalState: Equatable, Action: Equatable {
         case let .exhaustive(store):
             store.receive(expectedAction, update, file: file, line: line)
         case let .nonExhaustive(store):
-            store.receive(expectedAction, file: file, line: line, update)
+            store.receive(expectedAction, update, file: file, line: line)
         }
     }
 
@@ -194,7 +194,7 @@ extension TBCTestStore where LocalState: Equatable, Action: Equatable {
         case let .exhaustive(store):
             return await store.receive(expectedAction, update, file: file, line: line)
         case let .nonExhaustive(store):
-            store.receive(expectedAction, file: file, line: line, update)
+            return await store.receive(expectedAction, update, file: file, line: line)
         }
     }
 }


### PR DESCRIPTION
this makes the browser's test suite compile & green with async/await in non-exhaustive test-stores,  and mostly drops the manual requirements of tickling the async machinery. 

Things were copied over from TestStore and adjusted where required.

Going forward, we still want to drop the custom implementation and go back to upstream's version.

