### PR TITLE
Rescope tracking

### DIFF
--- a/Sources/ComposableArchitecture/Instrumentation.swift
+++ b/Sources/ComposableArchitecture/Instrumentation.swift
@@ -78,14 +78,14 @@ public class Instrumentation {
   private(set) var callback: Callback?
 
   /// Used to track when/where an instance was created
-  public typealias ObjectCreationCallback = (_ instance: AnyObject, _ file: StaticString, _ line: UInt) -> Void
+  public typealias ObjectCreationCallback = (_ instance: AnyObject, _ type: Any, _ parent: AnyObject?, _ file: StaticString, _ line: UInt) -> Void
 
   private(set) var viewStoreCreated: ObjectCreationCallback?
   private(set) var storeCreated: ObjectCreationCallback?
 
   public static let noop = Instrumentation()
 
-    public init(callback: Callback? = nil, viewStoreCreated: ObjectCreationCallback? = nil, storeCreated: ObjectCreationCallback? = nil) {
+  public init(callback: Callback? = nil, viewStoreCreated: ObjectCreationCallback? = nil, storeCreated: ObjectCreationCallback? = nil) {
     self.callback = callback
     self.viewStoreCreated = viewStoreCreated
     self.storeCreated = storeCreated
@@ -98,7 +98,6 @@ public class Instrumentation {
   ///   - callback: The callback invoked during the "life cycle" of the various stores within the app as an action is
   ///   acted upon.
   ///   - viewStoreCreated: Used to track when/where an instance of a ``ViewStore`` was created
-  ///   - storeCreated: Used to track when/where an instance of a ``Store`` was created
   public func update(callback: Callback? = nil, viewStoreCreated: ObjectCreationCallback? = nil, storeCreated: ObjectCreationCallback? = nil) {
     self.callback = callback
     self.viewStoreCreated = viewStoreCreated

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -147,6 +147,7 @@ public final class Store<State, Action> {
   public convenience init<R: ReducerProtocol>(
     initialState: @autoclosure () -> R.State,
     reducer: R,
+    parentStore: AnyObject? = nil,
     instrumentation: Instrumentation = .noop,
     prepareDependencies: ((inout DependencyValues) -> Void)? = nil,
     file: StaticString = #file,
@@ -157,6 +158,7 @@ public final class Store<State, Action> {
         initialState: withDependencies(prepareDependencies) { initialState() },
         reducer: reducer.transformDependency(\.self, transform: prepareDependencies),
         mainThreadChecksEnabled: true,
+        parentStore: parentStore,
         instrumentation: instrumentation,
         file: file,
         line: line
@@ -166,6 +168,7 @@ public final class Store<State, Action> {
         initialState: initialState(),
         reducer: reducer,
         mainThreadChecksEnabled: true,
+        parentStore: parentStore,
         instrumentation: instrumentation,
         file: file,
         line: line
@@ -643,6 +646,7 @@ public final class Store<State, Action> {
     initialState: R.State,
     reducer: R,
     mainThreadChecksEnabled: Bool,
+    parentStore: AnyObject? = nil,
     instrumentation: Instrumentation = .noop,
     file: StaticString = #file,
     line: UInt = #line
@@ -658,7 +662,7 @@ public final class Store<State, Action> {
     #endif
     self.instrumentation = instrumentation
     self.threadCheck(status: .`init`)
-    self.instrumentation.storeCreated?(self as AnyObject, file, line)
+    self.instrumentation.storeCreated?(self as AnyObject, Store<State, Action>.self, parentStore, file, line)
   }
 }
 
@@ -782,6 +786,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
       let childStore = Store<RescopedState, RescopedAction>(
         initialState: toRescopedState(store.state.value),
         reducer: reducer,
+        parentStore: store,
         instrumentation: instrumentation,
         file: file,
         line: line
@@ -880,6 +885,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
           }
         },
         removeDuplicates: isDuplicate,
+        parentStore: rootStore,
         instrumentation: instrumentation,
         file: file,
         line: line

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -545,14 +545,14 @@ public final class Store<State, Action> {
   }
 
   /// Returns a "stateless" store by erasing state to `Void`.
-  public var stateless: Store<Void, Action> {
-    self.scope(state: { _ in () })
+  public func stateless(file: StaticString = #file, line: UInt = #line) -> Store<Void, Action> {
+    self.scope(state: { _ in () }, file: file, line: line)
   }
 
   /// Returns an "actionless" store by erasing action to `Never`.
-  public var actionless: Store<State, Never> {
+  public func actionless(file: StaticString = #file, line: UInt = #line) -> Store<State, Never> {
     func absurd<A>(_ never: Never) -> A {}
-    return self.scope(state: { $0 }, action: absurd)
+    return self.scope(state: { $0 }, action: absurd, file: file, line: line)
   }
 
   private enum ThreadCheckStatus {

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -885,7 +885,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
           }
         },
         removeDuplicates: isDuplicate,
-        parentStore: rootStore,
+        parentStore: root,
         instrumentation: instrumentation,
         file: file,
         line: line

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -47,17 +47,23 @@ extension Store {
   ///   goes from `nil` to non-`nil` and vice versa, so that the caller can react to these changes.
   public func ifLet<Wrapped>(
     then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
-    else: @escaping () -> Void = {}
+    else: @escaping () -> Void = {},
+    file: StaticString = #file,
+    line: UInt = #line
   ) -> Cancellable where State == Wrapped? {
     return self.state
       .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
       .sink { state in
         if var state = state {
           unwrap(
-            self.scope {
-              state = $0 ?? state
-              return state
-            }
+            self.scope(
+                state: {
+                    state = $0 ?? state
+                    return state
+                },
+                file: file,
+                line: line
+            )
           )
         } else {
           `else`()

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -111,7 +111,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
         objectWillChange.send()
         _state.value = $0
       }
-    store.instrumentation.viewStoreCreated?(self as AnyObject, file, line)
+    store.instrumentation.viewStoreCreated?(self as AnyObject, ViewStore<ViewState, ViewAction>.self, nil, file, line)
   }
 
   /// Initializes a view store from a store which observes changes to state.
@@ -155,7 +155,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
         objectWillChange.send()
         _state.value = $0
       }
-    store.instrumentation.viewStoreCreated?(self as AnyObject, file, line)
+    store.instrumentation.viewStoreCreated?(self as AnyObject, ViewStore<ViewState, ViewAction>.self, nil, file, line)
   }
 
   /// Initializes a view store from a store.
@@ -253,7 +253,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
         _state.value = $0
       }
 
-    store.instrumentation.viewStoreCreated?(self as AnyObject, file, line)
+    store.instrumentation.viewStoreCreated?(self as AnyObject, ViewStore<ViewState, ViewAction>.self, nil, file, line)
   }
 
   /// Initializes a view store from a store that has a state of type void. This special initializer prevents this view
@@ -277,7 +277,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     }
     self._state = CurrentValueRelay(())
 
-    store.instrumentation.viewStoreCreated?(self as AnyObject, file, line)
+    store.instrumentation.viewStoreCreated?(self as AnyObject, ViewStore<ViewState, ViewAction>.self, nil, file, line)
   }
 
   internal init(_ viewStore: ViewStore<ViewState, ViewAction>, file: StaticString = #file, line: UInt = #line) {
@@ -287,7 +287,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     self.objectWillChange = viewStore.objectWillChange
     self.viewCancellable = viewStore.viewCancellable
 
-    self.instrumentation.viewStoreCreated?(self as AnyObject, file, line)
+    self.instrumentation.viewStoreCreated?(self as AnyObject, ViewStore<ViewState, ViewAction>.self, nil, file, line)
   }
 
   /// A publisher that emits when state changes.

--- a/Tests/ComposableArchitectureTests/InstrumentationTests.swift
+++ b/Tests/ComposableArchitectureTests/InstrumentationTests.swift
@@ -359,7 +359,7 @@ final class InstrumentationTests: XCTestCase {
   func test_tracks_viewStore_creation() {
     var viewStoreCreated: AnyObject?
 
-    let inst = ComposableArchitecture.Instrumentation(callback: nil, viewStoreCreated: { viewStore, _, _ in
+    let inst = ComposableArchitecture.Instrumentation(callback: nil, viewStoreCreated: { viewStore, _, _, _, _ in
       viewStoreCreated = viewStore
     })
 
@@ -376,7 +376,7 @@ final class InstrumentationTests: XCTestCase {
   func test_tracks_store_creation() {
     var storeCreated: AnyObject?
 
-    let inst = ComposableArchitecture.Instrumentation(callback: nil, storeCreated: { store, _, _ in
+    let inst = ComposableArchitecture.Instrumentation(callback: nil, storeCreated: { store, _, _, _, _ in
         storeCreated = store
     })
 


### PR DESCRIPTION
## Why?
I need ability to track both Parent and Child store relationship to be able to build a tree of scoping correctly

## Changes
Adds instrumentation callback for re-scope calls in our TCA fork that forwards both parent and child store types + location on when the scope was called in the codebase 

## Screenshots

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1468993/221843141-3ee384d3-75f6-4cfb-ad8a-5d87206c4f81.png">
