### PR TITLE
Add auto removeDuplicates when Equatable conformance exists

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -362,6 +362,15 @@ public final class Store<State, Action> {
     self.scope(state: toChildState, action: { $0 }, file: file, line: line)
   }
 
+public func scope<ChildState: Equatable, ChildAction>(
+  state toChildState: @escaping (State) -> ChildState,
+  action fromChildAction: @escaping (ChildAction) -> Action,
+  file: StaticString = #file,
+  line: UInt = #line
+) -> Store<ChildState, ChildAction> {
+  scope(state: toChildState, action: fromChildAction, removeDuplicates: ==, file: file, line: line)
+}
+
   func filter(
     _ isSent: @escaping (State, Action) -> Bool,
     file: StaticString = #file,


### PR DESCRIPTION
Adding automatic equatable conformance for testing in Canary, based on positive data from the [perf investigation](https://docs.google.com/spreadsheets/d/1kK3Tl2kMC9x6RdGv0ku9VteshTxOOajRPwnTnknSBUg/edit#gid=0)

We'll see if larger group sees any noticeable perf improvements
