### PR TITLE
Explicit remove duplicates

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -323,7 +323,6 @@ public final class Store<State, Action> {
     line: UInt = #line
   ) -> Store<ChildState, ChildAction> {
     self.threadCheck(status: .scope)
-
     #if swift(>=5.7)
       return self.reducer.rescope(
         self,
@@ -356,20 +355,12 @@ public final class Store<State, Action> {
   /// - Returns: A new store with its domain (state and action) transformed.
   public func scope<ChildState>(
     state toChildState: @escaping (State) -> ChildState,
+    removeDuplicates isDuplicate: ((ChildState, ChildState) -> Bool)? = nil,
     file: StaticString = #file,
     line: UInt = #line
   ) -> Store<ChildState, Action> {
-    self.scope(state: toChildState, action: { $0 }, file: file, line: line)
+    self.scope(state: toChildState, action: { $0 }, removeDuplicates: isDuplicate, file: file, line: line)
   }
-
-public func scope<ChildState: Equatable, ChildAction>(
-  state toChildState: @escaping (State) -> ChildState,
-  action fromChildAction: @escaping (ChildAction) -> Action,
-  file: StaticString = #file,
-  line: UInt = #line
-) -> Store<ChildState, ChildAction> {
-  scope(state: toChildState, action: fromChildAction, removeDuplicates: ==, file: file, line: line)
-}
 
   func filter(
     _ isSent: @escaping (State, Action) -> Bool,

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -47,6 +47,7 @@ extension Store {
   ///   goes from `nil` to non-`nil` and vice versa, so that the caller can react to these changes.
   public func ifLet<Wrapped>(
     then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
+    removeDuplicates isDuplicate: ((Wrapped, Wrapped) -> Bool)? = nil,
     else: @escaping () -> Void = {},
     file: StaticString = #file,
     line: UInt = #line
@@ -61,6 +62,7 @@ extension Store {
                     state = $0 ?? state
                     return state
                 },
+                removeDuplicates: isDuplicate,
                 file: file,
                 line: line
             )


### PR DESCRIPTION
## Changes
I want to have more control and require more thinking behind removeDuplicates as it doesn't make sense in some cases:

- no sense in adding it at ViewStore initialization
- no sense in isolated cell view states