### PR TITLE
Collapse down merge clauses (mirroring upstream).

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -508,10 +508,8 @@ extension EffectPublisher {
       return self
     case (.none, _):
       return other
-    case (.publisher(let pubA), .publisher(let pubB)):
-      return Self(operation: .publisher(Publishers.Merge(pubA, pubB).eraseToAnyPublisher()))
-    case (.run, .publisher(let publisher)), (.publisher(let publisher), .run):
-      return Self(operation: .publisher(Publishers.Merge(publisher, other).eraseToAnyPublisher()))
+    case (.publisher, .publisher), (.run, .publisher), (.publisher, .run):
+        return Self(operation: .publisher(Publishers.Merge(self, other).eraseToAnyPublisher()))
     case let (.run(lhsPriority, lhsOperation), .run(rhsPriority, rhsOperation)):
       return Self(
         operation: .run { send in

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -201,7 +201,8 @@ final class EffectCancellationTests: XCTestCase {
     ]
     let ids = (1...10).map { _ in UUID() }
     #if os(Windows)
-    let count = 100
+    // See https://github.com/thebrowsercompany/swift-composable-architecture/pull/45#discussion_r1274175528 for details on this value.
+    let count = 50
     #else
     let count = 1_000
     #endif


### PR DESCRIPTION
When working on https://github.com/thebrowsercompany/arc/pull/15987 (i.e. moving our Report Bug button into a Command Bar action) noticed that `.merge(…)`’d effects involving a mix of (Open)Combine publishers and Swift concurrency were completing when _any_ publisher in the merge finished instead of waiting for _all_ to finish. What this meant is the Command Bar would dismiss, but the effect to open the Bug Reporter (which is spawned via Swift Concurrency) never got a chance to run because the entire chain finished when the dismiss finished.

Pinned the culprit down to a subtle issue in our Windows fork. The pattern matches here where we reach into the `publisher` associated values sidesteps the [EffectPublisher.publisher](https://github.com/pointfreeco/swift-composable-architecture/blob/382e44f49b7df7f9a80ba25acbce298796d37cd9/Sources/ComposableArchitecture/Effects/Publisher.swift#L38C3-L81C3) helper which vends out the right publisher to subscribe to. This also mirrors [upstream’s implementation](https://github.com/pointfreeco/swift-composable-architecture/blob/382e44f49b7df7f9a80ba25acbce298796d37cd9/Sources/ComposableArchitecture/Effect.swift#L336-L337), so I’m guessing this was just an oversight in `feature/windows-explorations`.

To test this, https://github.com/thebrowsercompany/arc/pull/15987 works when pointing that change to use this commit and doesn’t when the package change is reverted.