### PR TITLE
Annotate the meta-Task returned by Store.send with MainActor

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -542,7 +542,7 @@ public final class Store<State, Action> {
     }
 
     guard !tasks.wrappedValue.isEmpty else { return nil }
-    return Task {
+    return Task { @MainActor in
       await withTaskCancellationHandler {
         var index = tasks.wrappedValue.startIndex
         while index < tasks.wrappedValue.endIndex {


### PR DESCRIPTION
## Description
ThreadSanitizer identified a race condition in the handling of the 'tasks'
box in Store.send. It is being accessed by the main thread and by a
background thread (while processing a task). Forcing that
meta task returned by Store.send to run on the Main Actor solves the
race condition warning and seems like the right thing to do.

There is an expectation that several Arc race conditions occuring in
production might be related to this, although given the non-determinism and the
relatively low occurrence compared to the number of users, we cannot be sure
until the fix is released.

## Tests
- Checked out this repo
- Change SPM to use the local version instead of fetching from github
- Enabled Thread Sanitizer
  happen consistently
- Build the app and confirmed that the race conditions happen consistently, 10
  out of 10.
- Apply this fix
- Build the app and confirmed that the race conditions never happen.
