### PR TITLE
Update Package File To Remove Custom Forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - release
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode 14.3
-        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+      - name: Select Xcode 14.3.1
+        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
       - name: Run ${{ matrix.config }} tests
         run: make CONFIG=${{ matrix.config }} test-library
 
@@ -48,8 +48,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode 14.3
-        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+      - name: Select Xcode 14.3.1
+        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
       - name: Build for library evolution
         run: make build-for-library-evolution
 
@@ -70,8 +70,8 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode 14.3
-        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+      - name: Select Xcode 14.3.1
+        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
       - name: Run benchmark
         run: make benchmark
 
@@ -79,7 +79,7 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+      - name: Select Xcode 14.3.1
+        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
       - name: Run tests
         run: make test-examples

--- a/Examples/TicTacToe/tic-tac-toe/Package.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "swift-composable-architecture", path: "../../.."),
-    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.0"),
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
   ],
   targets: [
     .target(

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,19 @@
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/thebrowsercompany/combine-schedulers",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "branch" : "feature/windows-explorations",
-        "revision" : "49bee662f821ce017a4ec8ad481b545b173bdf7f"
+        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "open-combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/thebrowsercompany/open-combine-schedulers",
+      "state" : {
+        "branch" : "main",
+        "revision" : "1563c2af3859dad33938d2053a9bff872da77699"
       }
     },
     {
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
-        "version" : "0.14.1"
+        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
+        "version" : "1.0.0"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "f9acfa1a45f4483fe0f2c434a74e6f68f865d12d",
-        "version" : "0.3.0"
+        "revision" : "d1fd837326aa719bee979bdde1f53cd5797443eb",
+        "version" : "1.0.0"
       }
     },
     {
@@ -64,12 +73,21 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "ea631ce892687f5432a833312292b80db238186a",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "505aa98716275fbd045d8f934fee3337c82ffbd3",
-        "version" : "0.10.3"
+        "revision" : "edd66cace818e1b1c6f1b3349bb1d8e00d6f8b01",
+        "version" : "1.0.0"
       }
     },
     {
@@ -77,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "25c9b6789b4b7ada649a3808e6d8de1489082a33",
-        "version" : "0.5.0"
+        "revision" : "4e1eb6e28afe723286d8cc60611237ffbddba7c5",
+        "version" : "1.0.0"
       }
     },
     {
@@ -113,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "47dd574b900ba5ba679f56ea00d4d282fc7305a6",
-        "version" : "0.7.1"
+        "revision" : "6eb293c49505d86e9e24232cb6af6be7fff93bd5",
+        "version" : "1.0.2"
       }
     },
     {
@@ -122,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4af50b38daf0037cfbab15514a241224c3f62f98",
-        "version" : "0.8.5"
+        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,15 +22,15 @@ let package = Package(
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     // currently produces a warning in SPM, but overrrides `Depdendencies`'s version with a version
     // that supports Windows via OpenCombine(Shims) (to fix warning, see thebrowsercompany/swift-dependencies below)
-    .package(url: "https://github.com/thebrowsercompany/combine-schedulers", branch: "feature/windows-explorations"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.14.0"),
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.9.1"),
-    // here to also link to https://github.com/thebrowsercompany/combine-schedulers, which supports OpenCombine
-    .package(url: "https://github.com/thebrowsercompany/swift-dependencies", branch: "feature/windows-explorations"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.7.0"),
-    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.7.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.5.0"),
+    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
+    .package(url: "https://github.com/thebrowsercompany/open-combine-schedulers", branch: "main")
   ],
   targets: [
     .target(
@@ -38,12 +38,21 @@ let package = Package(
       dependencies: [
         .product(name: "OpenCombineShim", package: "OpenCombine"),
         .product(name: "CasePaths", package: "swift-case-paths"),
-        .product(name: "CombineSchedulers", package: "combine-schedulers"),
+        .product(
+          name: "CombineSchedulers",
+          package: "combine-schedulers",
+          condition: .when(platforms: [.macOS, .iOS, .tvOS, .macCatalyst, .watchOS])
+        ),
+        .product(
+          name: "OpenCombineSchedulers",
+          package: "open-combine-schedulers",
+          condition: .when(platforms: [.windows])
+        ),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "IdentifiedCollections", package: "swift-identified-collections"),
         .product(name: "OrderedCollections", package: "swift-collections"),
-        .product(name: "_SwiftUINavigationState",
+        .product(name: "SwiftUINavigationCore",
           package: "swiftui-navigation",
           condition: .when(platforms: [.macOS, .iOS, .tvOS, .macCatalyst, .watchOS])),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ extension Target.Dependency {
 
   static var openCombine: Target.Dependency? {
     #if os(Windows)
-    .product(name: "OpenCombineShim", package: "OpenCombine")
+    .product(name: "OpenCombine", package: "OpenCombine")
     #else
     return nil
     #endif

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,6 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.13.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-    // currently produces a warning in SPM, but overrrides `Depdendencies`'s version with a version
-    // that supports Windows via OpenCombine(Shims) (to fix warning, see thebrowsercompany/swift-dependencies below)
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
@@ -30,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
-    .package(url: "https://github.com/thebrowsercompany/open-combine-schedulers", branch: "main")
+    .package(url: "https://github.com/thebrowsercompany/open-combine-schedulers", branch: "main"),
   ],
   targets: [
     .target(

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import Foundation
 import XCTestDynamicOverlay
 

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -1,5 +1,9 @@
 import Foundation
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 
 extension EffectPublisher {

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 @available(iOS, deprecated: 9999.0)
 @available(macOS, deprecated: 9999.0)

--- a/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 extension EffectPublisher {
   /// Turns an effect into one that can be debounced.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 extension EffectPublisher {
   /// Returns an effect that will be executed after given `dueTime`.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
@@ -1,6 +1,10 @@
 import Dispatch
 import Foundation
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 extension EffectPublisher {
   /// Throttles an effect so that it only publishes one output per given interval.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -1,5 +1,9 @@
 import CombineSchedulers
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 extension EffectPublisher where Failure == Never {
   /// Returns an effect that repeatedly emits the current time of the given scheduler on the given

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -1,5 +1,9 @@
 import Foundation
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 // https://github.com/CombineCommunity/CombineExt/blob/master/Sources/Operators/Create.swift
 

--- a/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
+++ b/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
@@ -1,5 +1,9 @@
 import Foundation
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 final class CurrentValueRelay<Output>: Publisher {
   typealias Failure = Never

--- a/Sources/ComposableArchitecture/Internal/Exports.swift
+++ b/Sources/ComposableArchitecture/Internal/Exports.swift
@@ -5,5 +5,5 @@
 @_exported import Dependencies
 @_exported import IdentifiedCollections
 #if canImport(SwiftUI)
-@_exported import _SwiftUINavigationState
+@_exported import SwiftUINavigationCore
 #endif

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -1,5 +1,9 @@
 import CasePaths
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 /// This API has been soft-deprecated in favor of ``ReducerProtocol``.
 /// Read <doc:MigratingToTheReducerProtocol> for more information.

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
@@ -1,5 +1,9 @@
 #if canImport(OSLog)
-  import OpenCombineShim
+  #if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
   import os.signpost
 
   extension AnyReducer {

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -1,5 +1,9 @@
 import Foundation
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 /// A store represents the runtime that powers the application. It is the object that you will pass
 /// around to views that need to interact with the application.

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1,5 +1,9 @@
 @_spi(Internals) import CasePaths
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import CustomDump
 import Foundation
 import XCTestDynamicOverlay

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 extension Store {
   /// Calls one of two closures depending on whether a store's optional state is `nil` or not, and

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 #if canImport(SwiftUI)
   import SwiftUI

--- a/Sources/ComposableArchitecture/WindowsSupport.swift
+++ b/Sources/ComposableArchitecture/WindowsSupport.swift
@@ -1,5 +1,4 @@
 import OpenCombineShim
-import OpenCombineSchedulers
 
 #if canImport(Combine)
   typealias CombineSubscription = Combine.Subscription
@@ -24,6 +23,7 @@ import Dependencies
 import Dispatch
 import Foundation
 import OpenCombineDispatch
+import OpenCombineSchedulers
 
 extension DependencyValues {
     public var mainQueue: AnySchedulerOf<DispatchQueue> {

--- a/Sources/ComposableArchitecture/WindowsSupport.swift
+++ b/Sources/ComposableArchitecture/WindowsSupport.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 #if canImport(Combine)
   typealias CombineSubscription = Combine.Subscription

--- a/Sources/ComposableArchitecture/WindowsSupport.swift
+++ b/Sources/ComposableArchitecture/WindowsSupport.swift
@@ -1,4 +1,5 @@
 import OpenCombineShim
+import OpenCombineSchedulers
 
 #if canImport(Combine)
   typealias CombineSubscription = Combine.Subscription

--- a/Sources/swift-composable-architecture-benchmark/Dependencies.swift
+++ b/Sources/swift-composable-architecture-benchmark/Dependencies.swift
@@ -1,5 +1,9 @@
 import Benchmark
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import Dependencies
 import Foundation

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -1,7 +1,11 @@
 import Benchmark
 import ComposableArchitecture
 import Foundation
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
   $0.benchmark("Merged Effect.none (create, flat)") {

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -1,5 +1,9 @@
 import ComposableArchitecture
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import XCTest
 
 @MainActor

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -1,6 +1,10 @@
 import CombineSchedulers
 import ComposableArchitecture
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import XCTest
 
 @MainActor

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
-  import OpenCombineShim
+  #if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
   import CustomDump
   import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -2,7 +2,11 @@
 
 import Dispatch
 
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectDeferredTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDeferredTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
-  import OpenCombineShim
+  #if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
   import ComposableArchitecture
   import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 @_spi(Canary)@_spi(Internals) import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import CustomDump
 import XCTest

--- a/Tests/ComposableArchitectureTests/StoreFilterTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreFilterTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
-  import OpenCombineShim
+  #if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
   import XCTest
 
   @testable import ComposableArchitecture

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 @_spi(Internals) import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
-  import OpenCombineShim
+  #if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
   import XCTest
   @_spi(Internals) import ComposableArchitecture
 

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 #if canImport(FoundationNetworking)

--- a/Tests/ComposableArchitectureTests/TimerTests.swift
+++ b/Tests/ComposableArchitectureTests/TimerTests.swift
@@ -1,4 +1,8 @@
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -1,6 +1,10 @@
 import ComposableArchitecture
 import Dispatch
-import OpenCombineShim
+#if canImport(OpenCombine)
+import OpenCombine
+#else
+import Combine
+#endif
 import XCTest
 
 @MainActor


### PR DESCRIPTION
This change allows us to remove our custom fork of both `swift-dependencies` and `combine-schedulers` since we can rely on the now-public package of  `open-combine-schedulers` instead of threading through changes by way of the other two forks we had.

You will also notice that in order to make this happen I had to update a few of the dependencies to newer versions which after talking with the Point-Free folks is totally fine (as long as tests are all passing) so we shouldn't worry about differences there.