### PR TITLE
Windows Support 1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,19 @@ jobs:
       - name: Run ${{ matrix.config }} tests
         run: make CONFIG=${{ matrix.config }} test-library
 
+  library-windows:
+    name: Library (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Swift
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8-release
+          tag: 5.8-RELEASE
+      - name: Build and test
+        run: swift test
+
   library-evolution:
     name: Library (evolution)
     runs-on: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install Swift
         uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.8-release
-          tag: 5.8-RELEASE
+          branch: swift-5.9.2-release
+          tag: 5.9.2-RELEASE
       - name: Build and test
         run: swift test
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug swift-composable-architecture-benchmark",
+            "program": "${workspaceFolder:swift-composable-architecture}\\.build/debug/swift-composable-architecture-benchmark",
+            "args": [],
+            "cwd": "${workspaceFolder:swift-composable-architecture}",
+            "preLaunchTask": "swift: Build Debug swift-composable-architecture-benchmark"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Release swift-composable-architecture-benchmark",
+            "program": "${workspaceFolder:swift-composable-architecture}\\.build/release/swift-composable-architecture-benchmark",
+            "args": [],
+            "cwd": "${workspaceFolder:swift-composable-architecture}",
+            "preLaunchTask": "swift: Build Release swift-composable-architecture-benchmark"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "swift",
+			"args": [
+				"build",
+				"--target",
+				"ComposableArchitecture",
+				"-Xswiftc",
+				"-g",
+				"-Xswiftc",
+				"-use-ld=link",
+			],
+			"cwd": ".",
+			"problemMatcher": [
+				"$swiftc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "swift: Build Debug ComposableArchitecture",
+			"detail": "swift build --target ComposableArchitecture ..."
+		},
+		{
+			"type": "swift",
+			"args": [
+				"build",
+				"-vvv",
+				"--target",
+				"ComposableArchitecture",
+				"-Xswiftc",
+				"-g",
+				"-Xswiftc",
+				"-use-ld=link",
+				"-j",
+				"1",
+			],
+			"cwd": ".",
+			"problemMatcher": [
+				"$swiftc"
+			],
+			"group": "build",
+			"label": "swift: Build Debug - Verbose Output - ComposableArchitecture",
+			"detail": "swift build --target ComposableArchitecture ..."
+		},
+		{
+			"type": "swift",
+			"args": [
+				"test",
+				"-Xswiftc",
+				"-g",
+				"-Xswiftc",
+				"-use-ld=link"
+			],
+			"cwd": ".",
+			"problemMatcher": [
+				"$swiftc"
+			],
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			},
+			"label": "swift: test",
+			"detail": "swift test ..."
+		},
+	]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,54 @@
 
 import PackageDescription
 
+// We have to conditionally declare the open-combine-schedulers code
+// (same goes for OpenCombine) so that we don't break binary packaging on macOS
+// Windows doesn't have an answer for binary frameworks for Swift
+// for the time being.
+extension Package.Dependency {
+  static var combineScheduler: Package.Dependency {
+    #if os(Windows)
+    .package(url: "https://github.com/thebrowsercompany/open-combine-schedulers", branch: "main")
+    #else
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0")
+    #endif
+  }
+
+  static var openCombine: Package.Dependency? {
+    #if os(Windows)
+    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.13.0")
+    #else
+    return nil
+    #endif
+  }
+}
+
+extension Target.Dependency {
+  static var combineScheduler: Target.Dependency {
+    #if os(Windows)
+    .product(
+      name: "OpenCombineSchedulers",
+      package: "open-combine-schedulers",
+      condition: .when(platforms: [.windows])
+    )
+    #else
+    .product(
+      name: "CombineSchedulers",
+      package: "combine-schedulers",
+      condition: .when(platforms: [.macOS, .iOS, .tvOS, .macCatalyst, .watchOS])
+    )
+    #endif
+  }
+
+  static var openCombine: Target.Dependency? {
+    #if os(Windows)
+    .product(name: "OpenCombine", package: "OpenCombine")
+    #else
+    return nil
+    #endif
+  }
+}
+
 let package = Package(
   name: "swift-composable-architecture",
   platforms: [
@@ -20,7 +68,6 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
@@ -28,21 +75,29 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
-  ],
+    .combineScheduler,
+    .openCombine
+  ].compactMap({ $0 }),
   targets: [
     .target(
       name: "ComposableArchitecture",
       dependencies: [
         .product(name: "CasePaths", package: "swift-case-paths"),
-        .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "IdentifiedCollections", package: "swift-identified-collections"),
         .product(name: "OrderedCollections", package: "swift-collections"),
-        .product(name: "SwiftUINavigationCore", package: "swiftui-navigation"),
+        .product(
+          name: "SwiftUINavigationCore",
+          package: "swiftui-navigation",
+          condition: .when(platforms: [.macOS, .iOS, .tvOS, .macCatalyst, .watchOS])
+        ),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
-      ]
+        .combineScheduler,
+        .openCombine
+      ].compactMap({ $0 }),
+      exclude: osSpecificComposableArchitectureExcludes()
     ),
     .testTarget(
       name: "ComposableArchitectureTests",
@@ -59,6 +114,17 @@ let package = Package(
     ),
   ]
 )
+
+func osSpecificComposableArchitectureExcludes() -> [String] {
+#if os(Windows)
+    return [
+        "SwiftUI",
+        "Internal/Deprecations.swift",
+    ]
+#else
+    return []
+#endif
+}
 
 //for target in package.targets where target.type != .system {
 //  target.swiftSettings = target.swiftSettings ?? []

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -1,6 +1,12 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 import XCTestDynamicOverlay
 
 public struct Effect<Action> {
@@ -135,6 +141,8 @@ extension Effect {
     Self(operation: .publisher(Just(action).eraseToAnyPublisher()))
   }
 
+  #if canImport(SwiftUI)
+
   /// Initializes an effect that immediately emits the action passed in.
   ///
   /// > Note: We do not recommend using `Effect.send` to share logic. Instead, limit usage to
@@ -149,6 +157,8 @@ extension Effect {
   public static func send(_ action: Action, animation: Animation? = nil) -> Self {
     .send(action).animation(animation)
   }
+  
+  #endif
 }
 
 /// A type that can send actions back into the system when used from
@@ -195,6 +205,8 @@ public struct Send<Action>: Sendable {
     self.send(action)
   }
 
+  #if canImport(SwiftUI)
+  
   /// Sends an action back into the system from an effect with animation.
   ///
   /// - Parameters:
@@ -215,6 +227,8 @@ public struct Send<Action>: Sendable {
       self(action)
     }
   }
+
+  #endif
 }
 
 // MARK: - Composing Effects

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -1,4 +1,10 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension Effect {
@@ -65,13 +71,13 @@ private struct TransactionPublisher<Upstream: Publisher>: Publisher {
   var upstream: Upstream
   var transaction: Transaction
 
-  func receive<S: Combine.Subscriber>(subscriber: S)
+  func receive<S: CombineSubscriber>(subscriber: S)
   where S.Input == Output, S.Failure == Failure {
     let conduit = Subscriber(downstream: subscriber, transaction: self.transaction)
     self.upstream.receive(subscriber: conduit)
   }
 
-  private final class Subscriber<Downstream: Combine.Subscriber>: Combine.Subscriber {
+  private final class Subscriber<Downstream: CombineSubscriber>: CombineSubscriber {
     typealias Input = Downstream.Input
     typealias Failure = Downstream.Failure
 
@@ -98,3 +104,5 @@ private struct TransactionPublisher<Upstream: Publisher>: Publisher {
     }
   }
 }
+
+#endif

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Foundation
 
 extension Effect {

--- a/Sources/ComposableArchitecture/Effects/Debounce.swift
+++ b/Sources/ComposableArchitecture/Effects/Debounce.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 
 extension Effect {
   /// Turns an effect into one that can be debounced.

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 
 extension Effect {
   /// Creates an effect from a Combine publisher.
@@ -32,7 +36,7 @@ public struct _EffectPublisher<Action>: Publisher {
     self.effect = effect
   }
 
-  public func receive<S: Combine.Subscriber>(
+  public func receive<S: CombineSubscriber>(
     subscriber: S
   ) where S.Input == Action, S.Failure == Failure {
     self.publisher.subscribe(subscriber)

--- a/Sources/ComposableArchitecture/Effects/Throttle.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttle.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Dispatch
 import Foundation
 

--- a/Sources/ComposableArchitecture/Internal/Binding+IsPresent.swift
+++ b/Sources/ComposableArchitecture/Internal/Binding+IsPresent.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension Binding {
@@ -11,3 +12,5 @@ extension Binding {
     )
   }
 }
+
+#endif

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -20,25 +20,42 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+#if canImport(Darwin)
 import Darwin
+#endif
+import Foundation
 
 final class DemandBuffer<S: Subscriber>: @unchecked Sendable {
   private var buffer = [S.Input]()
   private let subscriber: S
   private var completion: Subscribers.Completion<S.Failure>?
   private var demandState = Demand()
+  #if canImport(Darwin)
   private let lock: os_unfair_lock_t
+  #else
+  private let lock: NSRecursiveLock
+  #endif
 
   init(subscriber: S) {
     self.subscriber = subscriber
+    #if canImport(Darwin)
     self.lock = os_unfair_lock_t.allocate(capacity: 1)
     self.lock.initialize(to: os_unfair_lock())
+    #else
+    self.lock = NSRecursiveLock()
+    #endif
   }
 
   deinit {
+    #if canImport(Darwin)
     self.lock.deinitialize(count: 1)
     self.lock.deallocate()
+    #endif
   }
 
   func buffer(value: S.Input) -> Subscribers.Demand {
@@ -134,7 +151,7 @@ extension Publishers {
 }
 
 extension Publishers.Create {
-  fileprivate final class Subscription<Downstream: Subscriber>: Combine.Subscription
+  fileprivate final class Subscription<Downstream: Subscriber>: CombineSubscription
   where Downstream.Input == Output, Downstream.Failure == Never {
     private let buffer: DemandBuffer<Downstream>
     private var cancellable: Cancellable?

--- a/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
+++ b/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Foundation
 
 final class CurrentValueRelay<Output>: Publisher {
@@ -32,7 +36,7 @@ final class CurrentValueRelay<Output>: Publisher {
 }
 
 extension CurrentValueRelay {
-  final class Subscription<Downstream: Subscriber>: Combine.Subscription
+  final class Subscription<Downstream: Subscriber>: CombineSubscription
   where Downstream.Input == Output, Downstream.Failure == Failure {
     private var demandBuffer: DemandBuffer<Downstream>?
 

--- a/Sources/ComposableArchitecture/Internal/EphemeralState.swift
+++ b/Sources/ComposableArchitecture/Internal/EphemeralState.swift
@@ -8,6 +8,8 @@ public protocol _EphemeralState {
   static var actionType: Any.Type { get }
 }
 
+#if canImport(SwiftUI)
+
 extension AlertState: _EphemeralState {
   public static var actionType: Any.Type { Action.self }
 }
@@ -16,6 +18,8 @@ extension AlertState: _EphemeralState {
 extension ConfirmationDialogState: _EphemeralState {
   public static var actionType: Any.Type { Action.self }
 }
+
+#endif
 
 @usableFromInline
 func ephemeralType<State>(of state: State) -> (any _EphemeralState.Type)? {

--- a/Sources/ComposableArchitecture/Internal/Exports.swift
+++ b/Sources/ComposableArchitecture/Internal/Exports.swift
@@ -5,4 +5,7 @@
 @_exported import CustomDump
 @_exported import Dependencies
 @_exported import IdentifiedCollections
+
+#if canImport(SwiftUI)
 @_exported import SwiftUINavigationCore
+#endif

--- a/Sources/ComposableArchitecture/Internal/Locking.swift
+++ b/Sources/ComposableArchitecture/Internal/Locking.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if canImport(Darwin)
+
 extension UnsafeMutablePointer where Pointee == os_unfair_lock_s {
   @inlinable @discardableResult
   func sync<R>(_ work: () -> R) -> R {
@@ -8,6 +10,8 @@ extension UnsafeMutablePointer where Pointee == os_unfair_lock_s {
     return work()
   }
 }
+
+#endif
 
 extension NSRecursiveLock {
   @inlinable @discardableResult

--- a/Sources/ComposableArchitecture/Internal/Logger.swift
+++ b/Sources/ComposableArchitecture/Internal/Logger.swift
@@ -1,11 +1,19 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+#if canImport(OSLog)
 import OSLog
+#endif
 
 @_spi(Logging)
 public final class Logger {
   public static let shared = Logger()
   public var isEnabled = false
   @Published public var logs: [String] = []
-  #if DEBUG
+  #if DEBUG && canImport(OSLog)
     @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
     var logger: os.Logger {
       os.Logger(subsystem: "composable-architecture", category: "store-events")
@@ -26,6 +34,11 @@ public final class Logger {
       self.logs = []
     }
   #else
+    #if !canImport(OSLog)
+    public enum OSLogType {
+        case `default`, info, debug, error, fault
+    }
+    #endif
     @inlinable @inline(__always)
     public func log(level: OSLogType = .default, _ string: @autoclosure () -> String) {
     }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// A reducer that updates bindable state when it receives binding actions.
@@ -71,3 +72,5 @@ where State == ViewAction.State {
     return .none
   }
 }
+
+#endif

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Dispatch
 
 extension Reducer {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -1,5 +1,9 @@
 @_spi(Reflection) import CasePaths
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 
 /// A property wrapper for state that can be presented.
 ///

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -1,3 +1,4 @@
+#if canImport(OSLog)
 import OSLog
 
 extension Reducer {
@@ -138,6 +139,8 @@ extension Effect {
     }
   }
 }
+
+#endif
 
 @usableFromInline
 func debugCaseOutput(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -1,5 +1,9 @@
 @_spi(Reflection) import CasePaths
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Foundation
 import OrderedCollections
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -1,6 +1,12 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 /// A store represents the runtime that powers the application. It is the object that you will pass
 /// around to views that need to interact with the application.
@@ -205,6 +211,8 @@ public final class Store<State, Action> {
     .init(rawValue: self.send(action, originatingFrom: nil))
   }
 
+  #if canImport(SwiftUI)
+
   /// Sends an action to the store with a given animation.
   ///
   /// See ``Store/send(_:)`` for more info.
@@ -230,6 +238,8 @@ public final class Store<State, Action> {
       .init(rawValue: self.send(action, originatingFrom: nil))
     }
   }
+
+  #endif
 
   /// Scopes the store to one that exposes child state and actions.
   ///

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -182,8 +182,10 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
           """
         )
       }
+      return self.content(ViewStore(self.viewStore, file: file, line: line))
+    #else
+      return self.content(ViewStore(self.viewStore, file: #file, line: #line))
     #endif
-    return self.content(ViewStore(self.viewStore, file: file, line: line))
   }
 
   /// Initializes a structure that transforms a ``Store`` into an observable ``ViewStore`` in order

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1,5 +1,9 @@
 @_spi(Internals) import CasePaths
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ConcurrencyExtras
 import CustomDump
 import Foundation
@@ -1860,6 +1864,8 @@ extension TestStore {
   }
 }
 
+#if canImport(SwiftUI)
+
 extension TestStore {
   /// Returns a binding view store for this store.
   ///
@@ -1927,6 +1933,8 @@ extension TestStore where Action: BindableAction, State == Action.State {
     self.bindings(action: .self)
   }
 }
+
+#endif
 
 /// The type returned from ``TestStore/send(_:assert:file:line:)-1ax61`` that represents the
 /// lifecycle of the effect started from sending an action.
@@ -2212,6 +2220,7 @@ private func _XCTExpectFailure(
   failingBlock: () -> Void
 ) {
   #if DEBUG
+  #if !os(Windows)
     guard
       let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
         as Any as? NSObjectProtocol,
@@ -2227,8 +2236,10 @@ private func _XCTExpectFailure(
       dlsym(dlopen(nil, RTLD_LAZY), "XCTExpectFailureWithOptionsInBlock"),
       to: (@convention(c) (String?, AnyObject, () -> Void) -> Void).self
     )
-
     XCTExpectFailureWithOptionsInBlock(failureReason, options, failingBlock)
+  #else
+    print("Ignoring _XCTExpectFailure call on Windows platform.\n\nExpectedFailure: \(failureReason ?? "")")
+  #endif
   #endif
 }
 

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 
 extension Store {
   /// Calls one of two closures depending on whether a store's optional state is `nil` or not, and

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -1,5 +1,11 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 /// A `ViewStore` is an object that can observe state changes and send actions. They are most
 /// commonly used in views, such as SwiftUI views, UIView or UIViewController, but they can be used
@@ -268,6 +274,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     .init(rawValue: self._send(action))
   }
 
+  #if canImport(SwiftUI)
+
   /// Sends an action to the store with a given animation.
   ///
   /// See ``ViewStore/send(_:)`` for more info.
@@ -293,6 +301,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
       self.send(action)
     }
   }
+
+  #endif
 
   /// Sends an action into the store and then suspends while a piece of state is `true`.
   ///
@@ -378,6 +388,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     }
   }
 
+  #if canImport(SwiftUI)
+
   /// Sends an action into the store and then suspends while a piece of state is `true`.
   ///
   /// See the documentation of ``send(_:while:)`` for more information.
@@ -400,6 +412,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
       task.cancel()
     }
   }
+
+  #endif
 
   /// Suspends the current task while a predicate on state is `true`.
   ///
@@ -437,6 +451,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
       }
     }
   }
+
+  #if canImport(SwiftUI)
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends
   /// actions to the store.
@@ -585,6 +601,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
       }
     }
   }
+
+  #endif
 }
 
 /// A convenience type alias for referring to a view store of a given reducer's domain.
@@ -713,6 +731,14 @@ private struct HashableWrapper<Value>: Hashable {
   func hash(into hasher: inout Hasher) {}
 }
 
+#if canImport(SwiftUI)
 enum BindingLocal {
   @TaskLocal static var isActive = false
 }
+#else 
+// If SwiftUI is not available, we won't have any `Binding`s, so just hard-code to `false`
+struct BindingLocal {
+  static let isActive = false
+  private init() {}
+}
+#endif

--- a/Sources/ComposableArchitecture/WindowsSupport+Publisher-Merge.swift
+++ b/Sources/ComposableArchitecture/WindowsSupport+Publisher-Merge.swift
@@ -1,0 +1,694 @@
+#if !canImport(Combine)
+import OpenCombine
+
+// Verbatim copy of
+// https://github.com/cx-org/CombineX/blob/299bc0f8861f7aa6708780457aeeafab1c51eaa7/Sources/CombineX/Publishers/B/Merge.swift and
+// https://github.com/cx-org/CombineX/blob/299bc0f8861f7aa6708780457aeeafab1c51eaa7/Sources/CombineX/Publishers/B/Combined/Merge%2B.swift#L5
+// to make Effect's `merge` work on Windows using OpenCombine.
+
+// MIT License
+
+// Copyright (c) 2019 Quentin Jin
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+extension Publisher {
+
+    /// Combines elements from this publisher with those from another publisher, delivering an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    /// - Parameter other: Another publisher.
+    /// - Returns: A publisher that emits an event when either upstream publisher emits an event.
+    public func merge<P: Publisher>(with other: P) -> Publishers.Merge<Self, P> where Failure == P.Failure, Output == P.Output {
+        return .init(self, other)
+    }
+}
+
+extension Publishers.Merge: Equatable where A: Equatable, B: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality..
+    /// - Returns: `true` if the two merging - rhs: Another merging publisher to compare for equality.
+    public static func == (lhs: Publishers.Merge<A, B>, rhs: Publishers.Merge<A, B>) -> Bool {
+        return lhs.a == rhs.a && rhs.b == rhs.b
+    }
+}
+
+extension Publishers {
+
+    /// A publisher created by applying the merge function to two upstream publishers.
+    public struct Merge<A, B>: Publisher where A: Publisher, B: Publisher, A.Failure == B.Failure, A.Output == B.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B) {
+            self.a = a
+            self.b = b
+
+            self.pub = Publishers
+                .Sequence(sequence: [a.eraseToAnyPublisher(), b.eraseToAnyPublisher()])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where B.Failure == S.Failure, B.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge<P: Publisher>(with other: P) -> Publishers.Merge3<A, B, P> where B.Failure == P.Failure, B.Output == P.Output {
+            return .init(self.a, self.b, other)
+        }
+
+        public func merge<Z, Y>(with z: Z, _ y: Y) -> Publishers.Merge4<A, B, Z, Y> where Z: Publisher, Y: Publisher, B.Failure == Z.Failure, B.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output {
+            return .init(self.a, self.b, z, y)
+        }
+
+        public func merge<Z, Y, X>(with z: Z, _ y: Y, _ x: X) -> Publishers.Merge5<A, B, Z, Y, X> where Z: Publisher, Y: Publisher, X: Publisher, B.Failure == Z.Failure, B.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output {
+            return .init(self.a, self.b, z, y, x)
+        }
+
+        public func merge<Z, Y, X, W>(with z: Z, _ y: Y, _ x: X, _ w: W) -> Publishers.Merge6<A, B, Z, Y, X, W> where Z: Publisher, Y: Publisher, X: Publisher, W: Publisher, B.Failure == Z.Failure, B.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output, X.Failure == W.Failure, X.Output == W.Output {
+            return .init(self.a, self.b, z, y, x, w)
+        }
+
+        public func merge<Z, Y, X, W, V>(with z: Z, _ y: Y, _ x: X, _ w: W, _ v: V) -> Publishers.Merge7<A, B, Z, Y, X, W, V> where Z: Publisher, Y: Publisher, X: Publisher, W: Publisher, V: Publisher, B.Failure == Z.Failure, B.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output, X.Failure == W.Failure, X.Output == W.Output, W.Failure == V.Failure, W.Output == V.Output {
+            return .init(self.a, self.b, z, y, x, w, v)
+        }
+
+        public func merge<Z, Y, X, W, V, U>(with z: Z, _ y: Y, _ x: X, _ w: W, _ v: V, _ u: U) -> Publishers.Merge8<A, B, Z, Y, X, W, V, U> where Z: Publisher, Y: Publisher, X: Publisher, W: Publisher, V: Publisher, U: Publisher, B.Failure == Z.Failure, B.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output, X.Failure == W.Failure, X.Output == W.Output, W.Failure == V.Failure, W.Output == V.Output, V.Failure == U.Failure, V.Output == U.Output {
+            return .init(self.a, self.b, z, y, x, w, v, u)
+        }
+    }
+}
+
+extension Publisher {
+
+    /// Combines elements from this publisher with those from two other publishers, delivering an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    ///
+    /// - Parameters:
+    ///   - b: A second publisher.
+    ///   - c: A third publisher.
+    /// - Returns:  A publisher that emits an event when any upstream publisher emits
+    /// an event.
+    public func merge<B, C>(with b: B, _ c: C) -> Publishers.Merge3<Self, B, C> where B: Publisher, C: Publisher, Failure == B.Failure, Output == B.Output, B.Failure == C.Failure, B.Output == C.Output {
+        return .init(self, b, c)
+    }
+
+    /// Combines elements from this publisher with those from three other publishers, delivering
+    /// an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    ///
+    /// - Parameters:
+    ///   - b: A second publisher.
+    ///   - c: A third publisher.
+    ///   - d: A fourth publisher.
+    /// - Returns: A publisher that emits an event when any upstream publisher emits an event.
+    public func merge<B, C, D>(with b: B, _ c: C, _ d: D) -> Publishers.Merge4<Self, B, C, D> where B: Publisher, C: Publisher, D: Publisher, Failure == B.Failure, Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output {
+        return .init(self, b, c, d)
+    }
+
+    /// Combines elements from this publisher with those from four other publishers, delivering an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    ///
+    /// - Parameters:
+    ///   - b: A second publisher.
+    ///   - c: A third publisher.
+    ///   - d: A fourth publisher.
+    ///   - e: A fifth publisher.
+    /// - Returns: A publisher that emits an event when any upstream publisher emits an event.
+    public func merge<B, C, D, E>(with b: B, _ c: C, _ d: D, _ e: E) -> Publishers.Merge5<Self, B, C, D, E> where B: Publisher, C: Publisher, D: Publisher, E: Publisher, Failure == B.Failure, Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output {
+        return .init(self, b, c, d, e)
+    }
+
+    /// Combines elements from this publisher with those from five other publishers, delivering an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    ///
+    /// - Parameters:
+    ///   - b: A second publisher.
+    ///   - c: A third publisher.
+    ///   - d: A fourth publisher.
+    ///   - e: A fifth publisher.
+    ///   - f: A sixth publisher.
+    /// - Returns: A publisher that emits an event when any upstream publisher emits an event.
+    public func merge<B, C, D, E, F>(with b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Publishers.Merge6<Self, B, C, D, E, F> where B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, Failure == B.Failure, Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output, E.Failure == F.Failure, E.Output == F.Output {
+        return .init(self, b, c, d, e, f)
+    }
+
+    /// Combines elements from this publisher with those from six other publishers, delivering an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    ///
+    /// - Parameters:
+    ///   - b: A second publisher.
+    ///   - c: A third publisher.
+    ///   - d: A fourth publisher.
+    ///   - e: A fifth publisher.
+    ///   - f: A sixth publisher.
+    ///   - g: A seventh publisher.
+    /// - Returns: A publisher that emits an event when any upstream publisher emits an event.
+    public func merge<B, C, D, E, F, G>(with b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Publishers.Merge7<Self, B, C, D, E, F, G> where B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, Failure == B.Failure, Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output, E.Failure == F.Failure, E.Output == F.Output, F.Failure == G.Failure, F.Output == G.Output {
+        return .init(self, b, c, d, e, f, g)
+    }
+
+    /// Combines elements from this publisher with those from seven other publishers, delivering an interleaved sequence of elements.
+    ///
+    /// The merged publisher continues to emit elements until all upstream publishers finish. If an upstream publisher produces an error, the merged publisher fails with that error.
+    ///
+    /// - Parameters:
+    ///   - b: A second publisher.
+    ///   - c: A third publisher.
+    ///   - d: A fourth publisher.
+    ///   - e: A fifth publisher.
+    ///   - f: A sixth publisher.
+    ///   - g: A seventh publisher.
+    ///   - h: An eighth publisher.
+    /// - Returns: A publisher that emits an event when any upstream publisher emits an event.
+    public func merge<B, C, D, E, F, G, H>(with b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Publishers.Merge8<Self, B, C, D, E, F, G, H> where B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, H: Publisher, Failure == B.Failure, Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output, E.Failure == F.Failure, E.Output == F.Output, F.Failure == G.Failure, F.Output == G.Output, G.Failure == H.Failure, G.Output == H.Output {
+        return .init(self, b, c, d, e, f, g, h)
+    }
+
+    /// Combines elements from this publisher with those from another publisher of the same type, delivering an interleaved sequence of elements.
+    ///
+    /// - Parameter other: Another publisher of this publisher's type.
+    /// - Returns: A publisher that emits an event when either upstream publisher emits
+    /// an event.
+    public func merge(with other: Self) -> Publishers.MergeMany<Self> {
+        return .init(self, other)
+    }
+}
+
+extension Publishers.Merge3: Equatable where A: Equatable, B: Equatable, C: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality.
+    /// - Returns: `true` if the two merging publishers have equal source publishers, `false` otherwise.
+    public static func == (lhs: Publishers.Merge3<A, B, C>, rhs: Publishers.Merge3<A, B, C>) -> Bool {
+        return lhs.a == rhs.a
+            && lhs.b == rhs.b
+            && lhs.c == rhs.c
+    }
+}
+
+extension Publishers.Merge4: Equatable where A: Equatable, B: Equatable, C: Equatable, D: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality.
+    /// - Returns: `true` if the two merging publishers have equal source publishers, `false` otherwise.
+    public static func == (lhs: Publishers.Merge4<A, B, C, D>, rhs: Publishers.Merge4<A, B, C, D>) -> Bool {
+        return lhs.a == rhs.a
+            && lhs.b == rhs.b
+            && lhs.c == rhs.c
+            && lhs.d == rhs.d
+    }
+}
+
+extension Publishers.Merge5: Equatable where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality.
+    /// - Returns: `true` if the two merging publishers have equal source publishers, `false` otherwise.
+    public static func == (lhs: Publishers.Merge5<A, B, C, D, E>, rhs: Publishers.Merge5<A, B, C, D, E>) -> Bool {
+        return lhs.a == rhs.a
+            && lhs.b == rhs.b
+            && lhs.c == rhs.c
+            && lhs.d == rhs.d
+            && lhs.e == rhs.e
+    }
+}
+
+extension Publishers.Merge6: Equatable where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality.
+    /// - Returns: `true` if the two merging publishers have equal source publishers, `false` otherwise.
+    public static func == (lhs: Publishers.Merge6<A, B, C, D, E, F>, rhs: Publishers.Merge6<A, B, C, D, E, F>) -> Bool {
+        return lhs.a == rhs.a
+            && lhs.b == rhs.b
+            && lhs.c == rhs.c
+            && lhs.d == rhs.d
+            && lhs.e == rhs.e
+            && lhs.f == rhs.f
+    }
+}
+
+extension Publishers.Merge7: Equatable where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality.
+    /// - Returns: `true` if the two merging publishers have equal source publishers, `false` otherwise.
+    public static func == (lhs: Publishers.Merge7<A, B, C, D, E, F, G>, rhs: Publishers.Merge7<A, B, C, D, E, F, G>) -> Bool {
+        return lhs.a == rhs.a
+            && lhs.b == rhs.b
+            && lhs.c == rhs.c
+            && lhs.d == rhs.d
+            && lhs.e == rhs.e
+            && lhs.f == rhs.f
+            && lhs.g == rhs.g
+    }
+}
+
+extension Publishers.Merge8: Equatable where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable {
+
+    /// Returns a Boolean value that indicates whether two publishers are equivalent.
+    ///
+    /// - Parameters:
+    ///   - lhs: A merging publisher to compare for equality.
+    ///   - rhs: Another merging publisher to compare for equality.
+    /// - Returns: `true` if the two merging publishers have equal source publishers, `false` otherwise.
+    public static func == (lhs: Publishers.Merge8<A, B, C, D, E, F, G, H>, rhs: Publishers.Merge8<A, B, C, D, E, F, G, H>) -> Bool {
+        return lhs.a == rhs.a
+            && lhs.b == rhs.b
+            && lhs.c == rhs.c
+            && lhs.d == rhs.d
+            && lhs.e == rhs.e
+            && lhs.f == rhs.f
+            && lhs.g == rhs.g
+            && lhs.h == rhs.h
+    }
+}
+
+extension Publishers.MergeMany: Equatable where Upstream: Equatable {
+
+    public static func == (lhs: Publishers.MergeMany<Upstream>, rhs: Publishers.MergeMany<Upstream>) -> Bool {
+        return lhs.publishers == rhs.publishers
+    }
+}
+
+extension Publishers {
+
+    /// A publisher created by applying the merge function to three upstream publishers.
+    public struct Merge3<A, B, C>: Publisher where A: Publisher, B: Publisher, C: Publisher, A.Failure == B.Failure, A.Output == B.Output, B.Failure == C.Failure, B.Output == C.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        public let c: C
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B, _ c: C) {
+            self.a = a
+            self.b = b
+            self.c = c
+
+            self.pub = Publishers
+                .Sequence(sequence: [
+                    a.eraseToAnyPublisher(),
+                    b.eraseToAnyPublisher(),
+                    c.eraseToAnyPublisher()
+                ])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where C.Failure == S.Failure, C.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge<P: Publisher>(with other: P) -> Publishers.Merge4<A, B, C, P> where C.Failure == P.Failure, C.Output == P.Output {
+            return .init(a, b, c, other)
+        }
+
+        public func merge<Z, Y>(with z: Z, _ y: Y) -> Publishers.Merge5<A, B, C, Z, Y> where Z: Publisher, Y: Publisher, C.Failure == Z.Failure, C.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output {
+            return .init(a, b, c, z, y)
+        }
+
+        public func merge<Z, Y, X>(with z: Z, _ y: Y, _ x: X) -> Publishers.Merge6<A, B, C, Z, Y, X> where Z: Publisher, Y: Publisher, X: Publisher, C.Failure == Z.Failure, C.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output {
+            return .init(a, b, c, z, y, x)
+        }
+
+        public func merge<Z, Y, X, W>(with z: Z, _ y: Y, _ x: X, _ w: W) -> Publishers.Merge7<A, B, C, Z, Y, X, W> where Z: Publisher, Y: Publisher, X: Publisher, W: Publisher, C.Failure == Z.Failure, C.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output, X.Failure == W.Failure, X.Output == W.Output {
+            return .init(a, b, c, z, y, x, w)
+        }
+
+        public func merge<Z, Y, X, W, V>(with z: Z, _ y: Y, _ x: X, _ w: W, _ v: V) -> Publishers.Merge8<A, B, C, Z, Y, X, W, V> where Z: Publisher, Y: Publisher, X: Publisher, W: Publisher, V: Publisher, C.Failure == Z.Failure, C.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output, X.Failure == W.Failure, X.Output == W.Output, W.Failure == V.Failure, W.Output == V.Output {
+            return .init(a, b, c, z, y, x, w, v)
+        }
+    }
+
+    /// A publisher created by applying the merge function to four upstream publishers.
+    public struct Merge4<A, B, C, D>: Publisher where A: Publisher, B: Publisher, C: Publisher, D: Publisher, A.Failure == B.Failure, A.Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        public let c: C
+
+        public let d: D
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B, _ c: C, _ d: D) {
+            self.a = a
+            self.b = b
+            self.c = c
+            self.d = d
+
+            self.pub = Publishers
+                .Sequence(sequence: [
+                    a.eraseToAnyPublisher(),
+                    b.eraseToAnyPublisher(),
+                    c.eraseToAnyPublisher(),
+                    d.eraseToAnyPublisher()
+                ])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where D.Failure == S.Failure, D.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge<P: Publisher>(with other: P) -> Publishers.Merge5<A, B, C, D, P> where D.Failure == P.Failure, D.Output == P.Output {
+            return .init(a, b, c, d, other)
+        }
+
+        public func merge<Z, Y>(with z: Z, _ y: Y) -> Publishers.Merge6<A, B, C, D, Z, Y> where Z: Publisher, Y: Publisher, D.Failure == Z.Failure, D.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output {
+            return .init(a, b, c, d, z, y)
+        }
+
+        public func merge<Z, Y, X>(with z: Z, _ y: Y, _ x: X) -> Publishers.Merge7<A, B, C, D, Z, Y, X> where Z: Publisher, Y: Publisher, X: Publisher, D.Failure == Z.Failure, D.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output {
+            return .init(a, b, c, d, z, y, x)
+        }
+
+        public func merge<Z, Y, X, W>(with z: Z, _ y: Y, _ x: X, _ w: W) -> Publishers.Merge8<A, B, C, D, Z, Y, X, W> where Z: Publisher, Y: Publisher, X: Publisher, W: Publisher, D.Failure == Z.Failure, D.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output, X.Failure == W.Failure, X.Output == W.Output {
+            return .init(a, b, c, d, z, y, x, w)
+        }
+    }
+
+    /// A publisher created by applying the merge function to five upstream publishers.
+    public struct Merge5<A, B, C, D, E>: Publisher where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, A.Failure == B.Failure, A.Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        public let c: C
+
+        public let d: D
+
+        public let e: E
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) {
+            self.a = a
+            self.b = b
+            self.c = c
+            self.d = d
+            self.e = e
+
+            self.pub = Publishers
+                .Sequence(sequence: [
+                    a.eraseToAnyPublisher(),
+                    b.eraseToAnyPublisher(),
+                    c.eraseToAnyPublisher(),
+                    d.eraseToAnyPublisher(),
+                    e.eraseToAnyPublisher()
+                ])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where E.Failure == S.Failure, E.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge<P: Publisher>(with other: P) -> Publishers.Merge6<A, B, C, D, E, P> where E.Failure == P.Failure, E.Output == P.Output {
+            return .init(a, b, c, d, e, other)
+        }
+
+        public func merge<Z, Y>(with z: Z, _ y: Y) -> Publishers.Merge7<A, B, C, D, E, Z, Y> where Z: Publisher, Y: Publisher, E.Failure == Z.Failure, E.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output {
+            return .init(a, b, c, d, e, z, y)
+        }
+
+        public func merge<Z, Y, X>(with z: Z, _ y: Y, _ x: X) -> Publishers.Merge8<A, B, C, D, E, Z, Y, X> where Z: Publisher, Y: Publisher, X: Publisher, E.Failure == Z.Failure, E.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output, Y.Failure == X.Failure, Y.Output == X.Output {
+            return .init(a, b, c, d, e, z, y, x)
+        }
+    }
+
+    /// A publisher created by applying the merge function to six upstream publishers.
+    public struct Merge6<A, B, C, D, E, F>: Publisher where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, A.Failure == B.Failure, A.Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output, E.Failure == F.Failure, E.Output == F.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        public let c: C
+
+        public let d: D
+
+        public let e: E
+
+        public let f: F
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) {
+            self.a = a
+            self.b = b
+            self.c = c
+            self.d = d
+            self.e = e
+            self.f = f
+
+            self.pub = Publishers
+                .Sequence(sequence: [
+                    a.eraseToAnyPublisher(),
+                    b.eraseToAnyPublisher(),
+                    c.eraseToAnyPublisher(),
+                    d.eraseToAnyPublisher(),
+                    e.eraseToAnyPublisher(),
+                    f.eraseToAnyPublisher()
+                ])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where F.Failure == S.Failure, F.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge<P: Publisher>(with other: P) -> Publishers.Merge7<A, B, C, D, E, F, P> where F.Failure == P.Failure, F.Output == P.Output {
+            return .init(a, b, c, d, e, f, other)
+        }
+
+        public func merge<Z, Y>(with z: Z, _ y: Y) -> Publishers.Merge8<A, B, C, D, E, F, Z, Y> where Z: Publisher, Y: Publisher, F.Failure == Z.Failure, F.Output == Z.Output, Z.Failure == Y.Failure, Z.Output == Y.Output {
+            return .init(a, b, c, d, e, f, z, y)
+        }
+    }
+
+    /// A publisher created by applying the merge function to seven upstream publishers.
+    public struct Merge7<A, B, C, D, E, F, G>: Publisher where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, A.Failure == B.Failure, A.Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output, E.Failure == F.Failure, E.Output == F.Output, F.Failure == G.Failure, F.Output == G.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        public let c: C
+
+        public let d: D
+
+        public let e: E
+
+        public let f: F
+
+        public let g: G
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) {
+            self.a = a
+            self.b = b
+            self.c = c
+            self.d = d
+            self.e = e
+            self.f = f
+            self.g = g
+
+            self.pub = Publishers
+                .Sequence(sequence: [
+                    a.eraseToAnyPublisher(),
+                    b.eraseToAnyPublisher(),
+                    c.eraseToAnyPublisher(),
+                    d.eraseToAnyPublisher(),
+                    e.eraseToAnyPublisher(),
+                    f.eraseToAnyPublisher(),
+                    g.eraseToAnyPublisher()
+                ])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where G.Failure == S.Failure, G.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge<P: Publisher>(with other: P) -> Publishers.Merge8<A, B, C, D, E, F, G, P> where G.Failure == P.Failure, G.Output == P.Output {
+            return .init(a, b, c, d, e, f, g, other)
+        }
+    }
+
+    /// A publisher created by applying the merge function to eight upstream publishers.
+    public struct Merge8<A, B, C, D, E, F, G, H>: Publisher where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, H: Publisher, A.Failure == B.Failure, A.Output == B.Output, B.Failure == C.Failure, B.Output == C.Output, C.Failure == D.Failure, C.Output == D.Output, D.Failure == E.Failure, D.Output == E.Output, E.Failure == F.Failure, E.Output == F.Output, F.Failure == G.Failure, F.Output == G.Output, G.Failure == H.Failure, G.Output == H.Output {
+
+        public typealias Output = A.Output
+
+        public typealias Failure = A.Failure
+
+        public let a: A
+
+        public let b: B
+
+        public let c: C
+
+        public let d: D
+
+        public let e: E
+
+        public let f: F
+
+        public let g: G
+
+        public let h: H
+
+        let pub: AnyPublisher<A.Output, A.Failure>
+
+        public init(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) {
+            self.a = a
+            self.b = b
+            self.c = c
+            self.d = d
+            self.e = e
+            self.f = f
+            self.g = g
+            self.h = h
+
+            self.pub = Publishers
+                .Sequence(sequence: [
+                    a.eraseToAnyPublisher(),
+                    b.eraseToAnyPublisher(),
+                    c.eraseToAnyPublisher(),
+                    d.eraseToAnyPublisher(),
+                    e.eraseToAnyPublisher(),
+                    f.eraseToAnyPublisher(),
+                    g.eraseToAnyPublisher(),
+                    h.eraseToAnyPublisher()
+                ])
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where H.Failure == S.Failure, H.Output == S.Input {
+            self.pub.subscribe(subscriber)
+        }
+    }
+
+    public struct MergeMany<Upstream: Publisher>: Publisher {
+
+        public typealias Output = Upstream.Output
+
+        public typealias Failure = Upstream.Failure
+
+        public let publishers: [Upstream]
+
+        let pub: AnyPublisher<Upstream.Output, Upstream.Failure>
+
+        public init(_ upstream: Upstream...) {
+            self.publishers = upstream
+
+            self.pub = Publishers
+                .Sequence(sequence: upstream)
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public init<S: Swift.Sequence>(_ upstream: S) where Upstream == S.Element {
+            self.publishers = Array(upstream)
+
+            self.pub = Publishers
+                .Sequence(sequence: upstream)
+                .flatMap { $0 }
+                .eraseToAnyPublisher()
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where Upstream.Failure == S.Failure, Upstream.Output == S.Input {
+
+            self.pub.subscribe(subscriber)
+        }
+
+        public func merge(with other: Upstream) -> Publishers.MergeMany<Upstream> {
+            return .init(Array(self.publishers) + [other])
+        }
+    }
+}
+#endif

--- a/Sources/ComposableArchitecture/WindowsSupport.swift
+++ b/Sources/ComposableArchitecture/WindowsSupport.swift
@@ -1,0 +1,55 @@
+#if canImport(Combine)
+import Combine
+typealias CombineSubscription = Combine.Subscription
+public typealias CombineSubscriber = Combine.Subscriber
+#elseif canImport(OpenCombine)
+import OpenCombine
+typealias CombineSubscription = OpenCombine.Subscription
+public typealias CombineSubscriber = OpenCombine.Subscriber
+#endif
+
+#if os(Windows)
+// provide missing symbols from Dispatch
+public let NSEC_PER_MSEC: UInt64 = 1_000_000
+public let NSEC_PER_SEC: UInt64 = 1_000_000_000
+
+public var uncheckedUseMainSerialExecutor: Bool = false
+#endif
+
+// `Dependencies` gates some Dependencies on `Combine` (vs `OpenCombineShim`).
+// So temporarily add our own versions here.
+// Could maybe allow Dependencies to work with `OpenCombine` also?
+#if !canImport(Combine)
+import CombineSchedulers
+import Dependencies
+import Dispatch
+import Foundation
+import OpenCombineDispatch
+import OpenCombineSchedulers
+
+extension DependencyValues {
+    public var mainQueue: AnySchedulerOf<DispatchQueue> {
+      get { self[MainQueueKey.self] }
+      set { self[MainQueueKey.self] = newValue }
+    }
+
+    private enum MainQueueKey: DependencyKey {
+      static let liveValue = AnySchedulerOf<DispatchQueue>.main
+      static let testValue = AnySchedulerOf<DispatchQueue>
+        .unimplemented(#"@Dependency(\.mainQueue)"#)
+    }
+}
+
+extension DependencyValues {
+  public var mainRunLoop: AnySchedulerOf<RunLoop> {
+    get { self[MainRunLoopKey.self] }
+    set { self[MainRunLoopKey.self] = newValue }
+  }
+
+  private enum MainRunLoopKey: DependencyKey {
+    static let liveValue = AnySchedulerOf<RunLoop>.main
+    static let testValue = AnySchedulerOf<RunLoop>.unimplemented(#"@Dependency(\.mainRunLoop)"#)
+  }
+}
+
+#endif

--- a/Sources/ComposableArchitecture/WindowsSupport.swift
+++ b/Sources/ComposableArchitecture/WindowsSupport.swift
@@ -25,6 +25,7 @@ import Dependencies
 import Dispatch
 import Foundation
 import OpenCombineDispatch
+import OpenCombineFoundation
 import OpenCombineSchedulers
 
 extension DependencyValues {

--- a/Sources/swift-composable-architecture-benchmark/Dependencies.swift
+++ b/Sources/swift-composable-architecture-benchmark/Dependencies.swift
@@ -1,5 +1,9 @@
 import Benchmark
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import Dependencies
 import Foundation

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -1,5 +1,9 @@
 import Benchmark
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import Foundation
 

--- a/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
@@ -1,5 +1,9 @@
 import Benchmark
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 @_spi(Internals) import ComposableArchitecture
 import Foundation
 

--- a/Sources/swift-composable-architecture-benchmark/ViewStore.swift
+++ b/Sources/swift-composable-architecture-benchmark/ViewStore.swift
@@ -1,5 +1,9 @@
 import Benchmark
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import Foundation
 

--- a/Tests/ComposableArchitectureTests/BindableStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/BindableStoreTests.swift
@@ -1,5 +1,11 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 @_spi(Internals) import ComposableArchitecture
+
+#if canImport(SwiftUI)
 import SwiftUI
 import XCTest
 
@@ -220,3 +226,5 @@ final class BindableStoreTests: XCTestCase {
     )
   }
 }
+
+#endif

--- a/Tests/ComposableArchitectureTests/BindingLocalTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingLocalTests.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG && canImport(SwiftUI)
   import XCTest
 
   @testable import ComposableArchitecture

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import XCTest
 
@@ -9,7 +13,7 @@ final class CompatibilityTests: BaseTCATestCase {
   // Actions can be re-entrantly sent into the store if an action is sent that holds an object
   // which sends an action on deinit. In order to prevent a simultaneous access exception for this
   // case we need to use `withExtendedLifetime` on the buffered actions when clearing them out.
-  func testCaseStudy_ActionReentranceFromClearedBufferCausingDeinitAction() {
+  func testCaseStudy_ActionReentranceFromClearedBufferCausingDeinitAction() async {
     let cancelID = UUID()
 
     struct State: Equatable {}
@@ -81,7 +85,7 @@ final class CompatibilityTests: BaseTCATestCase {
   // In particular, this means that in the implementation of `Store.send` we need to flip
   // `isSending` to false _after_ the store's state mutation is made so that re-entrant actions
   // are buffered rather than immediately handled.
-  func testCaseStudy_ActionReentranceFromStateObservation() {
+  func testCaseStudy_ActionReentranceFromStateObservation() async {
     let store = Store<Int, Int>(initialState: 0) {
       Reduce { state, action in
         state = action

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import CombineSchedulers
 import ComposableArchitecture
 import XCTest
@@ -7,6 +11,7 @@ import XCTest
 final class ComposableArchitectureTests: BaseTCATestCase {
   var cancellables: Set<AnyCancellable> = []
 
+  @MainActor
   func testScheduling() async {
     struct Counter: Reducer {
       typealias State = Int
@@ -67,6 +72,7 @@ final class ComposableArchitectureTests: BaseTCATestCase {
     await store.receive(.squareNow) { $0 = 391876 }
   }
 
+  @MainActor
   func testSimultaneousWorkOrdering() {
     let mainQueue = DispatchQueue.test
 
@@ -83,6 +89,7 @@ final class ComposableArchitectureTests: BaseTCATestCase {
     XCTAssertEqual(values, [1, 42, 1, 1, 42])
   }
 
+  @MainActor
   func testLongLivingEffects() async {
     enum Action { case end, incr, start }
 
@@ -115,6 +122,7 @@ final class ComposableArchitectureTests: BaseTCATestCase {
     await store.send(.end)
   }
 
+  @MainActor
   func testCancellation() async {
     let mainQueue = DispatchQueue.test
 

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
+  #if canImport(Combine)
   import Combine
+  #elseif canImport(OpenCombine)
+  import OpenCombine
+  #endif
   import CustomDump
   import XCTest
 
@@ -42,6 +46,8 @@
         "DebugTests.Action.screenA(.row(index:, action: .textChanged(query:)))"
       )
     }
+
+    #if canImport(SwiftUI)
 
     func testBindingAction() {
       struct State {
@@ -96,6 +102,8 @@
         )
       #endif
     }
+
+    #endif
 
     @MainActor
     func testDebugReducer() async throws {

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -1,4 +1,9 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+import Dispatch
 @_spi(Internals) import ComposableArchitecture
 import XCTest
 
@@ -330,8 +335,14 @@ final class EffectCancellationTests: BaseTCATestCase {
       ]
       let ids = (1...10).map { _ in UUID() }
 
+      #if os(Windows)
+      // See https://github.com/thebrowsercompany/swift-composable-architecture/pull/45#discussion_r1274175528 for details on this value.
+      let count = 50
+      #else
+      let count = 1_000
+      #endif
       let effect = Effect.merge(
-        (1...1_000).map { idx -> Effect<Int> in
+        (1...count).map { idx -> Effect<Int> in
           let id = ids[idx % 10]
 
           return .merge(
@@ -376,8 +387,14 @@ final class EffectCancellationTests: BaseTCATestCase {
       XCTAssertTrue(!Thread.isMainThread)
       let ids = (1...100).map { _ in UUID() }
 
+    #if os(Windows)
+      // See https://github.com/thebrowsercompany/swift-composable-architecture/pull/45#discussion_r1274175528 for details on this value.
+      let count = 100
+      #else
+      let count = 10_000
+      #endif
       let areCancelled = await withTaskGroup(of: Bool.self, returning: [Bool].self) { group in
-        (1...10_000).forEach { index in
+        (1...count).forEach { index in
           let id = ids[index.quotientAndRemainder(dividingBy: ids.count).remainder]
           group.addTask {
             await withTaskCancellation(id: id) {

--- a/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 @_spi(Internals) import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
-  import Combine
+  #if canImport(Combine)
+import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
   @_spi(Internals) import ComposableArchitecture
   import XCTest
 
@@ -7,7 +11,9 @@
   final class EffectFailureTests: BaseTCATestCase {
     var cancellables: Set<AnyCancellable> = []
 
-    func testRunUnexpectedThrows() async {
+    func testRunUnexpectedThrows() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
 
       var line: UInt!

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import XCTest
 
@@ -44,7 +48,9 @@ final class EffectRunTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testRunUnhandledFailure() async {
+    func testRunUnhandledFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
@@ -124,7 +130,9 @@ final class EffectRunTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testRunEscapeFailure() async {
+    func testRunEscapeFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       XCTExpectFailure {
         $0.compactDescription == """
           An action was sent from a completed effect:

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 @_spi(Canary) @_spi(Internals) import ComposableArchitecture
 import XCTest
 
@@ -7,7 +11,7 @@ final class EffectTests: BaseTCATestCase {
   var cancellables: Set<AnyCancellable> = []
   let mainQueue = DispatchQueue.test
 
-  #if (canImport(RegexBuilder) || !os(macOS) && !targetEnvironment(macCatalyst))
+  #if (canImport(RegexBuilder) || !os(macOS) && !targetEnvironment(macCatalyst)) && !os(Windows)
     func testConcatenate() async {
       if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
         await withMainSerialExecutor {

--- a/Tests/ComposableArchitectureTests/Hacks.swift
+++ b/Tests/ComposableArchitectureTests/Hacks.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+#if os(Windows)
+import XCTest
+
+func XCTSkipIfWindowsExpectFailure(file: StaticString = #fileID, line: UInt = #line) throws {
+  throw XCTSkip("XCTExpectFailure is currently not supported on Windows.", file: file, line: line)
+}
+
+struct XCTIssue {
+  var compactDescription: String
+}
+
+@_disfavoredOverload
+func XCTExpectFailure<R>(
+  _ failureReason: String? = nil,
+  enabled: Bool? = nil,
+  strict: Bool? = nil,
+  failingBlock: () throws -> R,
+  issueMatcher: ((XCTIssue) -> Bool)? = nil,
+  file: StaticString = #fileID,
+  line: UInt = #line
+) rethrows -> R? {
+  print(warnFail(message: failureReason ?? ""))
+  return nil
+}
+
+@_disfavoredOverload
+func XCTExpectFailure(
+  _ failureReason: String? = nil,
+  enabled: Bool? = nil,
+  strict: Bool? = nil,
+  issueMatcher: ((XCTIssue) -> Bool)? = nil,
+  file: StaticString = #fileID,
+  line: UInt = #line
+) {
+  print(warnFail(message: failureReason ?? ""))
+}
+
+private func warnFail(message: String) -> String {
+  return """
+    XCTExpectFailure: \(message)
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+    ┃ ⚠︎ Warning: This XCTExpectFailure was ignored.
+    ┃
+    ┃ XCTExpectFailure is currently not supported on Windows.
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+        ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
+    """
+}
+#else
+
+func XCTSkipIfWindowsExpectFailure(file: StaticString = #fileID, line: UInt = #line) throws {}
+
+#endif

--- a/Tests/ComposableArchitectureTests/InstrumentationTests.swift
+++ b/Tests/ComposableArchitectureTests/InstrumentationTests.swift
@@ -2,7 +2,11 @@
 #if canImport(OpenCombine)
 import OpenCombine
 #else
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 #endif
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -1,8 +1,15 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 @_spi(Internals) import ComposableArchitecture
 import CustomDump
 import XCTest
+
+#if canImport(OSLog)
 import os.signpost
+#endif
 
 @MainActor
 final class ReducerTests: BaseTCATestCase {
@@ -105,6 +112,8 @@ final class ReducerTests: BaseTCATestCase {
     XCTAssertTrue(second)
   }
 
+  #if canImport(OSLog)
+
   func testDefaultSignpost() async {
     let reducer = EmptyReducer<Int, Void>().signpost(log: .default)
     var n = 0
@@ -116,4 +125,6 @@ final class ReducerTests: BaseTCATestCase {
     var n = 0
     for await _ in reducer.reduce(into: &n, action: ()).actions {}
   }
+
+  #endif
 }

--- a/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
@@ -1,3 +1,5 @@
+#if canImport(SwiftUI)
+
 import ComposableArchitecture
 import XCTest
 
@@ -126,3 +128,5 @@ final class BindingTests: BaseTCATestCase {
     _ = (/Foo.bar).extract(from: .bar(.buzz(true)))
   }
 }
+
+#endif

--- a/Tests/ComposableArchitectureTests/Reducers/ForEachReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/ForEachReducerTests.swift
@@ -36,7 +36,9 @@ final class ForEachReducerTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testMissingElement() async {
+    func testMissingElement() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       let store = TestStore(initialState: Elements.State()) {
         EmptyReducer<Elements.State, Elements.Action>()
           .forEach(\.rows, action: /Elements.Action.row) {}

--- a/Tests/ComposableArchitectureTests/Reducers/IfCaseLetReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/IfCaseLetReducerTests.swift
@@ -31,7 +31,9 @@ final class IfCaseLetReducerTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testNilChild() async {
+    func testNilChild() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       struct SomeError: Error, Equatable {}
 
       let store = TestStore(initialState: Result.failure(SomeError())) {

--- a/Tests/ComposableArchitectureTests/Reducers/IfLetReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/IfLetReducerTests.swift
@@ -4,7 +4,9 @@ import XCTest
 @MainActor
 final class IfLetReducerTests: BaseTCATestCase {
   #if DEBUG
-    func testNilChild() async {
+    func testNilChild() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       let store = TestStore(initialState: Int?.none) {
         EmptyReducer<Int?, Void>()
           .ifLet(\.self, action: /.self) {}
@@ -204,6 +206,7 @@ final class IfLetReducerTests: BaseTCATestCase {
     }
   }
 
+  #if canImport(SwiftUI)
   func testEphemeralState() async {
     if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
       struct Parent: Reducer {
@@ -240,6 +243,7 @@ final class IfLetReducerTests: BaseTCATestCase {
       }
     }
   }
+  #endif
 
   func testIdentifiableChild() async {
     struct Feature: Reducer {
@@ -308,6 +312,7 @@ final class IfLetReducerTests: BaseTCATestCase {
     }
   }
 
+  #if canImport(SwiftUI)
   func testEphemeralDismissal() async {
     struct Feature: Reducer {
       struct State: Equatable {
@@ -345,4 +350,5 @@ final class IfLetReducerTests: BaseTCATestCase {
       $0.alert = nil
     }
   }
+  #endif
 }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -1,3 +1,5 @@
+#if canImport(SwiftUI)
+
 import ComposableArchitecture
 import XCTest
 
@@ -2542,3 +2544,5 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
   }
 }
+
+#endif

--- a/Tests/ComposableArchitectureTests/Reducers/StackReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/StackReducerTests.swift
@@ -18,7 +18,9 @@ final class StackReducerTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testStackStateSubscriptCase_Unexpected() {
+    func testStackStateSubscriptCase_Unexpected() throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Element: Equatable {
         case int(Int)
         case text(String)
@@ -230,7 +232,9 @@ final class StackReducerTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testDismissReceiveWrongAction() async {
+    func testDismissReceiveWrongAction() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Child: Reducer {
         struct State: Equatable {}
         enum Action: Equatable { case tap }
@@ -734,7 +738,9 @@ final class StackReducerTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testSendActionWithIDThatDoesNotExist() async {
+    func testSendActionWithIDThatDoesNotExist() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Parent: Reducer {
         struct State: Equatable {
           var path = StackState<Int>()
@@ -784,7 +790,9 @@ final class StackReducerTests: BaseTCATestCase {
   #endif
 
   #if DEBUG
-    func testPopIDThatDoesNotExist() async {
+    func testPopIDThatDoesNotExist() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Parent: Reducer {
         struct State: Equatable {
           var path = StackState<Int>()
@@ -818,7 +826,11 @@ final class StackReducerTests: BaseTCATestCase {
     }
   #endif
 
-  func testChildWithInFlightEffect() async {
+  #if !os(Windows)
+  // Windows build fails on type-checking complexity.
+  func testChildWithInFlightEffect() async throws {
+    try XCTSkipIfWindowsExpectFailure()
+
     struct Child: Reducer {
       struct State: Equatable {}
       enum Action { case tap }
@@ -873,6 +885,7 @@ final class StackReducerTests: BaseTCATestCase {
             """
     }
   }
+  #endif
 
   func testMultipleChildEffects() async {
     struct Child: Reducer {
@@ -1024,7 +1037,9 @@ final class StackReducerTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testPushReusedID() async {
+    func testPushReusedID() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Child: Reducer {
         struct State: Equatable {}
         enum Action: Equatable {}
@@ -1068,7 +1083,9 @@ final class StackReducerTests: BaseTCATestCase {
   #endif
 
   #if DEBUG
-    func testPushIDGreaterThanNextGeneration() async {
+    func testPushIDGreaterThanNextGeneration() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Child: Reducer {
         struct State: Equatable {}
         enum Action: Equatable {}
@@ -1109,7 +1126,9 @@ final class StackReducerTests: BaseTCATestCase {
       }
     }
 
-    func testMismatchedIDFailure() async {
+    func testMismatchedIDFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       struct Child: Reducer {
         struct State: Equatable {}
         enum Action: Equatable {}

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -1,10 +1,16 @@
 #if DEBUG
-  import Combine
+  #if canImport(Combine)
+import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
   import ComposableArchitecture
   import XCTest
 
   final class RuntimeWarningTests: BaseTCATestCase {
-    func testStoreCreationMainThread() {
+    func testStoreCreationMainThread() throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       uncheckedUseMainSerialExecutor = false
       XCTExpectFailure {
         $0.compactDescription == """
@@ -21,7 +27,9 @@
       _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
     }
 
-    func testEffectFinishedMainThread() {
+    func testEffectFinishedMainThread() throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       XCTExpectFailure {
         $0.compactDescription == """
           An effect completed on a non-main thread. …
@@ -55,7 +63,9 @@
       _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
     }
 
-    func testStoreScopeMainThread() {
+    func testStoreScopeMainThread() throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       uncheckedUseMainSerialExecutor = false
       XCTExpectFailure {
         [
@@ -82,7 +92,9 @@
       _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
     }
 
-    func testViewStoreSendMainThread() {
+    func testViewStoreSendMainThread() throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       uncheckedUseMainSerialExecutor = false
       XCTExpectFailure {
         [
@@ -189,6 +201,8 @@
       }
     #endif
 
+    #if canImport(SwiftUI)
+    
     @MainActor
     func testBindingUnhandledAction() {
       let line = #line + 2
@@ -240,5 +254,8 @@
           """
       }
     }
+
+    #endif
+
   }
 #endif

--- a/Tests/ComposableArchitectureTests/ScopeTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeTests.swift
@@ -39,7 +39,9 @@ final class ScopeTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testNilChild() async {
+    func testNilChild() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       let store = TestStore(initialState: Child2.State.count(0)) {
         Scope(state: /Child2.State.name, action: /Child2.Action.name) {}
       }

--- a/Tests/ComposableArchitectureTests/StoreFilterTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreFilterTests.swift
@@ -1,5 +1,9 @@
 #if DEBUG
-  import Combine
+  #if canImport(Combine)
+import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
   import XCTest
 
   @testable import ComposableArchitecture
@@ -8,7 +12,7 @@
   final class StoreFilterTests: BaseTCATestCase {
     var cancellables: Set<AnyCancellable> = []
 
-    func testFilter() {
+    func testFilter() async {
       let store = Store<Int?, Void>(initialState: nil) {}
         .invalidate { $0 != nil }
 

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1,4 +1,11 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @_spi(Internals) import ComposableArchitecture
 import XCTest
 
@@ -695,6 +702,8 @@ final class StoreTests: BaseTCATestCase {
   }
 
   func testChildParentEffectCancellation() async throws {
+    try XCTSkipIfWindowsExpectFailure()
+
     struct Child: Reducer {
       struct State: Equatable {}
       enum Action: Equatable {

--- a/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 @_spi(Internals) import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/TaskResultTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskResultTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 final class TaskResultTests: BaseTCATestCase {
   #if DEBUG
-    func testEqualityNonEquatableError() {
+    func testEqualityNonEquatableError() throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Failure: Error {
         let message: String
       }
@@ -26,7 +28,9 @@ final class TaskResultTests: BaseTCATestCase {
       }
     }
 
-    func testEqualityMismatchingError() {
+    func testEqualityMismatchingError() throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Failure1: Error {
         let message: String
       }
@@ -53,7 +57,9 @@ final class TaskResultTests: BaseTCATestCase {
       }
     }
 
-    func testHashabilityNonHashableError() {
+    func testHashabilityNonHashableError() throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       struct Failure: Error {
         let message: String
       }

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -4,7 +4,9 @@
 
   @MainActor
   final class TestStoreFailureTests: BaseTCATestCase {
-    func testNoStateChangeFailure() async {
+    func testNoStateChangeFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Action { case first, second }
       let store = TestStore(initialState: 0) {
         Reduce<Int, Action> { state, action in
@@ -36,7 +38,9 @@
       await store.receive(.second) { _ = $0 }
     }
 
-    func testStateChangeFailure() async {
+    func testStateChangeFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct State: Equatable { var count = 0 }
       let store = TestStore(initialState: State()) {
         Reduce<State, Void> { state, action in
@@ -58,7 +62,9 @@
       await store.send(()) { $0.count = 0 }
     }
 
-    func testUnexpectedStateChangeOnSendFailure() async {
+    func testUnexpectedStateChangeOnSendFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct State: Equatable { var count = 0 }
       let store = TestStore(initialState: State()) {
         Reduce<State, Void> { state, action in
@@ -80,7 +86,9 @@
       await store.send(())
     }
 
-    func testUnexpectedStateChangeOnReceiveFailure() async {
+    func testUnexpectedStateChangeOnReceiveFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct State: Equatable { var count = 0 }
       enum Action { case first, second }
       let store = TestStore(initialState: State()) {
@@ -108,7 +116,9 @@
       await store.receive(.second)
     }
 
-    func testReceivedActionAfterDeinit() async {
+    func testReceivedActionAfterDeinit() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Action { case first, second }
       let store = TestStore(initialState: 0) {
         Reduce<Int, Action> { state, action in
@@ -130,7 +140,9 @@
       await store.send(.first)
     }
 
-    func testEffectInFlightAfterDeinit() async {
+    func testEffectInFlightAfterDeinit() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: 0) {
         Reduce<Int, Void> { state, action in
           .run { _ in try await Task.never() }
@@ -163,7 +175,9 @@
       await store.send(())
     }
 
-    func testSendActionBeforeReceivingFailure() async {
+    func testSendActionBeforeReceivingFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Action { case first, second }
       let store = TestStore(initialState: 0) {
         Reduce<Int, Action> { state, action in
@@ -191,7 +205,9 @@
       await store.receive(.second)
     }
 
-    func testReceiveNonExistentActionFailure() async {
+    func testReceiveNonExistentActionFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Action { case action }
       let store = TestStore(initialState: 0) {
         Reduce<Int, Action> { _, _ in .none }
@@ -207,7 +223,9 @@
       await store.receive(.action)
     }
 
-    func testReceiveUnexpectedActionFailure() async {
+    func testReceiveUnexpectedActionFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Action { case first, second }
       let store = TestStore(initialState: 0) {
         Reduce<Int, Action> { state, action in
@@ -236,7 +254,9 @@
       await store.receive(.first)
     }
 
-    func testModifyClosureThrowsErrorFailure() async {
+    func testModifyClosureThrowsErrorFailure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: 0) {
         Reduce<Int, Void> { _, _ in .none }
       }
@@ -250,7 +270,9 @@
       }
     }
 
-    func testExpectedStateEqualityMustModify() async {
+    func testExpectedStateEqualityMustModify() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       let store = TestStore(initialState: 0) {
         Reduce<Int, Bool> { state, action in
           switch action {

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -23,7 +23,9 @@
       XCTAssertEqual(store.state, 2)
     }
 
-    func testSkipReceivedActions_Strict() async {
+    func testSkipReceivedActions_Strict() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: 0) {
         Reduce<Int, Bool> { state, action in
           if action {
@@ -97,7 +99,9 @@
       await store.skipInFlightEffects(strict: false)
     }
 
-    func testCancelInFlightEffects_Strict() async {
+    func testCancelInFlightEffects_Strict() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: 0) {
         Reduce<Int, Bool> { _, action in
           .run { _ in }
@@ -219,7 +223,9 @@
 
     // Confirms that you don't have to assert on all state changes in a non-exhaustive test store,
     // *but* if you make an incorrect mutation you will still get a failure.
-    func testNonExhaustiveSend_PartialExhaustive_BadAssertion() async {
+    func testNonExhaustiveSend_PartialExhaustive_BadAssertion() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: Counter.State()) {
         Counter()
       }
@@ -303,7 +309,9 @@
 
     // Confirms that if you receive an action in a non-exhaustive test store with a bad assertion
     // you will still get a failure.
-    func testSend_SkipReceivedActions_BadAssertion() async {
+    func testSend_SkipReceivedActions_BadAssertion() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Feature: Reducer {
         struct State: Equatable {
           var count = 0
@@ -609,7 +617,9 @@
       }
     }
 
-    func testCasePathReceive_WrongAction() async {
+    func testCasePathReceive_WrongAction() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: NonExhaustiveReceive.State()) {
         NonExhaustiveReceive()
       }
@@ -628,7 +638,9 @@
       await store.receive(/NonExhaustiveReceive.Action.response2)
     }
 
-    func testCasePathReceive_ReceivedExtraAction() async {
+    func testCasePathReceive_ReceivedExtraAction() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       let store = TestStore(initialState: NonExhaustiveReceive.State()) {
         NonExhaustiveReceive()
       }
@@ -646,7 +658,9 @@
       await store.receive(/NonExhaustiveReceive.Action.response2)
     }
 
-    func testXCTModifyExhaustive() async {
+    func testXCTModifyExhaustive() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct State: Equatable {
         var child: Int? = 0
         var count = 0
@@ -738,7 +752,9 @@
       await store.receive(.response2, timeout: 1_000_000_000)
     }
 
-    func testReceiveNonExhaustiveWithTimeoutMultipleNonMatching() async {
+    func testReceiveNonExhaustiveWithTimeoutMultipleNonMatching() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Feature: Reducer {
         struct State: Equatable {}
         enum Action: Equatable { case tap, response1, response2 }
@@ -866,7 +882,9 @@
       XCTAssertEqual(store.state.age, 34)
     }
 
-    func testEffectfulAssertion_NonExhaustiveTestStore_ShowSkippedAssertions() async {
+    func testEffectfulAssertion_NonExhaustiveTestStore_ShowSkippedAssertions() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct Model: Equatable {
         let id: UUID
         init() {

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -1,4 +1,11 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import ComposableArchitecture
 import XCTest
 
@@ -76,7 +83,9 @@ final class TestStoreTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testExpectedStateEquality() async {
+    func testExpectedStateEquality() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct State: Equatable {
         var count: Int = 0
         var isChanging: Bool = false
@@ -123,7 +132,9 @@ final class TestStoreTests: BaseTCATestCase {
       }
     }
 
-    func testExpectedStateEqualityMustModify() async {
+    func testExpectedStateEqualityMustModify() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       struct State: Equatable {
         var count: Int = 0
       }
@@ -157,7 +168,9 @@ final class TestStoreTests: BaseTCATestCase {
       }
     }
 
-    func testReceiveActionMatchingPredicate() async {
+    func testReceiveActionMatchingPredicate() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+
       enum Action: Equatable {
         case noop, finished
       }
@@ -436,7 +449,9 @@ final class TestStoreTests: BaseTCATestCase {
   }
 
   #if DEBUG
-    func testAssert_NonExhaustiveTestStore_Failure() async {
+    func testAssert_NonExhaustiveTestStore_Failure() async throws {
+      try XCTSkipIfWindowsExpectFailure()
+      
       let store = TestStore(initialState: 0) {
         EmptyReducer<Int, Void>()
       }

--- a/Tests/ComposableArchitectureTests/ThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/ThrottleTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import XCTest
 

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#elseif canImport(OpenCombine)
+import OpenCombine
+#endif
 import ComposableArchitecture
 import XCTest
 


### PR DESCRIPTION
This re-integrates Windows support for version 1.3.

I pulled in some changes from `develop` like the `.vscode` directory, the `ci.yml` addition, etc., but most of it was just adding the conditional imports and blocking out Apple-specific code.