### PR TITLE
Cancel Effects Using All Navigation Path Prefixes

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -274,9 +274,11 @@ public class CancellablesCollection {
     id: ID,
     path: NavigationIDPath
   ) {
-    let cancelID = _CancelID(id: id, navigationIDPath: path)
-    self.storage[cancelID]?.forEach { $0.cancel() }
-    self.storage[cancelID] = nil
+    for navigationIDPath in path.prefixes {
+      let cancelID = _CancelID(id: id, navigationIDPath: navigationIDPath)
+      self.storage[cancelID]?.forEach { $0.cancel() }
+      self.storage[cancelID] = nil
+    }
   }
 
   func exists<ID: Hashable>(


### PR DESCRIPTION
This patches the internal cancellation code to work around an issue we've discovered with the new (to us) `NavigationIDPath` machinery.

This issue manifests when an `Effect` is made `cancellable` from a "parent" reducer, but actually cancelled in a "child" reducer. Although this is kind of an anti-pattern, we do it in several places—notably, web content setup and teardown. In such cases, the effects are not actually being cancelled right now!